### PR TITLE
[PB-3099] feat: remove deferred class usage from OlmAdapter

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -8,4 +8,8 @@ declare global {
         RTCRtpScriptTransform: Window.RTCRtpScriptTransform;
         onrtctransform: Window.onrtctransform;
     }
+
+    declare class RTCRtpScriptTransform {
+        constructor(worker: Worker, options?: any);
+    }
 }

--- a/modules/browser/BrowserCapabilities.js
+++ b/modules/browser/BrowserCapabilities.js
@@ -20,9 +20,6 @@ const FROZEN_MACOS_VERSION = '10.15.7';
  * Implements browser capabilities for lib-jitsi-meet.
  */
 export default class BrowserCapabilities extends BrowserDetection {
-    isWebKitBased() {
-        throw new Error('Method not implemented.');
-    }
     /**
      * Tells whether or not the <tt>MediaStream/tt> is removed from the <tt>PeerConnection</tt> and disposed on video
      * mute (in order to turn off the camera device). This is needed on Firefox because of the following bug

--- a/modules/e2ee/E2EEncryption.ts
+++ b/modules/e2ee/E2EEncryption.ts
@@ -1,5 +1,3 @@
-import base64js from "base64-js";
-
 import browser from "../browser";
 
 import { ManagedKeyHandler } from "./ManagedKeyHandler";
@@ -53,7 +51,7 @@ export class E2EEncryption {
      * @param {boolean} enabled - whether E2EE should be enabled or not.
      * @returns {void}
      */
-    async setEnabled(enabled) {
+    async setEnabled(enabled: boolean): Promise<void> {
         await this._keyHandler.setEnabled(enabled);
     }
 

--- a/modules/xmpp/strophe.util.ts
+++ b/modules/xmpp/strophe.util.ts
@@ -51,6 +51,7 @@ export default function() {
         // Strophe log entry about secondary request timeout does not mean that
         // it's a final failure(the request will be restarted), so we lower it's
         // level here to a warning.
+        // This line can be commented out if you are having perfomance problems while debugging on Chrome.
         logger.trace('Strophe', level, msg);
         if (typeof msg === 'string'
                 && msg.indexOf('Request ') !== -1


### PR DESCRIPTION
Removed usage of Deferred class from OlmAdapter.

- SessionInitializationInProgress variable added to prevent multiple calls to initSessions.
- this._init is used just to check if the OLM adapter is initialized, it should be initialized when users access to the meeting as it loads even if e2ee is not enabled.
- Deferred was deprecated. We just started using raw Promises, the pattern of resolving promises after a while is not avoidable as this flow is pretty async and we rely on users sending back ACK messages.

To consider:

- There are still some problems like the audio sometimes not working as expected if you enable e2ee, however, you can check that the encryption keys are being shared successfully from the keys manager.
- Like on the original implementation, when a moderator enables e2ee, it enables that feature for ALL users in the meeting, this triggers an `_onParticipantPropertyChanged` event, which calls `sendKeyInfoToAll` event, which leads to sometimes seeing messages such as "session not initialized with user xxxxxx".  This is not related to any race issues and keys should be shared with users despite this. 
Check: https://github.com/internxt/lib-jitsi-meet/blob/7ed448780db67a5548716ea4858dff6b1c8be61b/modules/e2ee/OlmAdapter.ts#L1466
- I had performance problems while debugging the project due to trophy logging too many times things to the console while on DEBUG mode, you can avoid this by commenting out one line, it makes debugging much faster.

