### PR TITLE
[PB-3907] Fix session establishment

### DIFF
--- a/modules/RTC/JitsiRemoteTrack.js
+++ b/modules/RTC/JitsiRemoteTrack.js
@@ -153,7 +153,7 @@ export default class JitsiRemoteTrack extends JitsiTrack {
             && !this.listenerCount(JitsiTrackEvents.TRACK_STREAMING_STATUS_CHANGED)
         ) {
             this._disposeTrackStreamingStatus();
-            logger.debug(`Disposing track streaming status: ${this._sourceName}`);
+            //logger.debug(`Disposing track streaming status: ${this._sourceName}`);
         }
     }
 

--- a/modules/e2ee/Context.ts
+++ b/modules/e2ee/Context.ts
@@ -161,7 +161,7 @@ export class Context {
             return encryptData(iv, additionalData, key, data).then(
                 (cipherText) => {
                     if (print) {
-                        console.log("E2E: Start encryption!");
+                        console.log("E2E: Start encryption of my data!");
                         print = false;
                     }
                     const newData = new ArrayBuffer(
@@ -312,7 +312,7 @@ export class Context {
 
             return encodedFrame;
         } catch (error) {
-            console.error(`E2E: Got error while decrypting frame: ${error}`);
+            console.error(`E2E: Got error while decrypting frame from ${this._participantId}: ${error}`);
         }
     }
 

--- a/modules/e2ee/Context.ts
+++ b/modules/e2ee/Context.ts
@@ -1,5 +1,5 @@
 /* global BigInt */
-import { deriveKeys, ratchet, encryptData, decryptData } from "./crypto-utils";
+import { deriveKeys, ratchet, encryptData, decryptData, importKey } from "./crypto-utils";
 
 // We use a ringbuffer of keys so we can change them and still decode packets that were
 // encrypted with an old key. We use a size of 16 which corresponds to the four bits
@@ -29,8 +29,8 @@ const IV_LENGTH = 16;
 
 export type KeyMaterial = {
     encryptionKey: CryptoKey;
-    materialOlm: Uint8Array;
-    materialPQ: Uint8Array;
+    materialOlm: CryptoKey;
+    materialPQ: CryptoKey;
 };
 
 /**
@@ -61,10 +61,13 @@ export class Context {
     async ratchetKeys() {
         const currentIndex = this._currentKeyIndex;
         const { materialOlm, materialPQ } = this._cryptoKeyRing[currentIndex];
-        const newMaterialOlm = await ratchet(materialOlm);
-        const newMaterialPQ = await ratchet(materialPQ);
+        const newOlmKey = await ratchet(materialOlm);
+        const newPQkey = await ratchet(materialPQ);
+        const newMaterialOlm = await importKey(newOlmKey);
+        const newMaterialPQ = await importKey(newPQkey);
+        const encryptionKey = await deriveKeys(newOlmKey, newPQkey);
+        this.setKeyMaterial(newMaterialOlm, newMaterialPQ, encryptionKey, currentIndex + 1);
         console.info(`E2E: Ratchet keys for ${this._participantId}`);
-        this.setKey(newMaterialOlm, newMaterialPQ, currentIndex + 1);
     }
 
     /**
@@ -75,11 +78,17 @@ export class Context {
      * @param {Number} index
      */
     async setKey(olmKey: Uint8Array, pqKey: Uint8Array, index: number = -1) {
-        const newEncryptionKey = await deriveKeys(olmKey, pqKey);
+        const encryptionKey = await deriveKeys(olmKey, pqKey);
+        const materialOlm = await importKey(olmKey);
+        const materialPQ = await importKey(pqKey);
+        this.setKeyMaterial(materialOlm, materialPQ, encryptionKey, index);
+    }
+
+    setKeyMaterial(materialOlm: CryptoKey, materialPQ: CryptoKey, encryptionKey: CryptoKey, index: number = -1) {
         const newKey: KeyMaterial = {
-            materialOlm: olmKey,
-            materialPQ: pqKey,
-            encryptionKey: newEncryptionKey,
+            materialOlm,
+            materialPQ,
+            encryptionKey,
         };
         if (index >= 0) {
             this._currentKeyIndex = index % this._cryptoKeyRing.length;

--- a/modules/e2ee/ManagedKeyHandler.ts
+++ b/modules/e2ee/ManagedKeyHandler.ts
@@ -240,7 +240,7 @@ export class ManagedKeyHandler extends Listenable {
 
     /**
      * Advances (using ratcheting) the current key when a new participant joins the conference.
-     * Sends a session-init to a new participant if their ID is bigger than ours.
+     * Sends a session-init to a new participant if their ID is bigger than ID of this user.
      * 
      * @private
      */

--- a/modules/e2ee/ManagedKeyHandler.ts
+++ b/modules/e2ee/ManagedKeyHandler.ts
@@ -240,15 +240,20 @@ export class ManagedKeyHandler extends Listenable {
 
     /**
      * Advances (using ratcheting) the current key when a new participant joins the conference.
+     * Sends a session-init to a new participant if their ID is bigger than ours.
+     * 
      * @private
      */
-    _onParticipantJoined() {
+    _onParticipantJoined(id: string) {
         logger.info(
-            `E2E: A new participant joined the conference`,
+            `E2E: A new participant ${id} joined the conference`,
         );
         if (this._conferenceJoined && this.enabled) {
             this._ratchetKeyImpl();
-            this._olmAdapter.initSessions();
+            if (id > this.conference.myUserId()) {
+                const participant = this.conference.getParticipantById(id);
+                this._olmAdapter._sendSessionInit(participant);
+            }
         }
     }
 

--- a/modules/e2ee/ManagedKeyHandler.ts
+++ b/modules/e2ee/ManagedKeyHandler.ts
@@ -248,6 +248,7 @@ export class ManagedKeyHandler extends Listenable {
         );
         if (this._conferenceJoined && this.enabled) {
             this._ratchetKeyImpl();
+            this._olmAdapter.initSessions();
         }
     }
 

--- a/modules/e2ee/OlmAdapter.ts
+++ b/modules/e2ee/OlmAdapter.ts
@@ -18,7 +18,6 @@ import {
     encryptKeyInfoPQ,
     generateKey,
     ratchet,
-    importKey,
 } from "./crypto-utils";
 import JitsiConference from "../../JitsiConference";
 import JitsiParticipant from "../../JitsiParticipant";
@@ -359,7 +358,7 @@ export class OlmAdapter extends Listenable {
             const localParticipantId = this._conf.myUserId();
             const participants = this._conf.getParticipants();
             logger.debug(
-                `E2E: All participants  ${participants.map(p => p.getId())}`,
+                `E2E: List of all participants:  ${participants.map(p => p.getId())}`,
             );
             const list = participants.filter(
                 (participant) =>
@@ -367,7 +366,7 @@ export class OlmAdapter extends Listenable {
                     localParticipantId < participant.getId(),
             );
             logger.debug(
-                `E2E: Passed filter  ${list.map(p => p.getId())}`,
+                `E2E: Based on IDs, we should send session-init to those participants:  ${list.map(p => p.getId())}`,
             );
             const promises = list.map((participant) =>
                 this._sendSessionInit(participant),
@@ -1492,16 +1491,13 @@ export class OlmAdapter extends Listenable {
      * @private
      */
     async _sendSessionInit(participant: JitsiParticipant) {
-        logger.debug(
-            `E2E: Entered _sendSessionInit ${participant.getDisplayName()} `,
-        );
         const olmData = this._getParticipantOlmData(participant);
         if (olmData.status === PROTOCOL_STATUS.DONE) return;
 
         const pId = participant.getId();
         if (olmData.status === PROTOCOL_STATUS.NOT_STARTED) {
             logger.info(
-                `E2E: sending session init to ${participant.getDisplayName()} `,
+                `E2E: Sending session init to participant ${participant.getDisplayName()} `,
             );
             try {
                 // Generate a One Time Key.
@@ -1512,7 +1508,7 @@ export class OlmAdapter extends Listenable {
 
                 if (!values.length || typeof values[0] !== "string") {
                     return Promise.reject(
-                        new Error("No one-time-keys generated"),
+                        new Error("E2E: No one-time-keys generated"),
                     );
                 }
 
@@ -1530,7 +1526,7 @@ export class OlmAdapter extends Listenable {
                 const timeoutPromise = new Promise((_, reject) =>
                     setTimeout(
                         () =>
-                            reject(new Error("Session init request timed out")),
+                            reject(new Error("E2E: Session init request timed out")),
                         REQ_TIMEOUT,
                     ),
                 );

--- a/modules/e2ee/OlmAdapter.ts
+++ b/modules/e2ee/OlmAdapter.ts
@@ -410,10 +410,8 @@ export class OlmAdapter extends Listenable {
      */
     async _ratchetKeyImpl() {
         try {
-            const materialOlm = await importKey(this._mediaKeyOlm);
-            const materialPQ = await importKey(this._mediaKeyPQ);
-            this._mediaKeyOlm = await ratchet(materialOlm);
-            this._mediaKeyPQ = await ratchet(materialPQ);
+            this._mediaKeyOlm = await ratchet(this._mediaKeyOlm);
+            this._mediaKeyPQ = await ratchet(this._mediaKeyPQ);
             this._mediaKeyIndex++;
             this.ratchetAllKeys();
         } catch (error) {

--- a/modules/e2ee/OlmAdapter.ts
+++ b/modules/e2ee/OlmAdapter.ts
@@ -323,11 +323,14 @@ export class OlmAdapter extends Listenable {
                     );
                     break;
                 case "e2ee.enabled":
-                    if (newValue) {
+                    if (newValue) logger.info(
+                        `E2E: Participant ${participant.getId()} started encrypting their data.`,
+                    );
+                    /*if (newValue) {
                         await this.initSessions();
                     } else {
                         this.clearParticipantSession(participant);
-                    }
+                    }*/
                     break;
             }
         }
@@ -339,7 +342,12 @@ export class OlmAdapter extends Listenable {
      * @private
      */
     async initSessions() {
-        if (this._sessionInitializationInProgress) return;
+        if (this._sessionInitializationInProgress) {
+            logger.info(
+                `E2E: initSessions is already in progress.`,
+            );
+            return;
+        }
         this._sessionInitializationInProgress = true;
 
         if (!(await this._olmWasInitialized)) {
@@ -351,10 +359,16 @@ export class OlmAdapter extends Listenable {
         try {
             const localParticipantId = this._conf.myUserId();
             const participants = this._conf.getParticipants();
+            logger.debug(
+                `E2E: All participants  ${participants.map(p => p.getId())}`,
+            );
             const list = participants.filter(
                 (participant) =>
                     participant.hasFeature(FEATURE_E2EE) &&
                     localParticipantId < participant.getId(),
+            );
+            logger.debug(
+                `E2E: Passed filter  ${list.map(p => p.getId())}`,
             );
             const promises = list.map((participant) =>
                 this._sendSessionInit(participant),

--- a/modules/e2ee/OlmAdapter.ts
+++ b/modules/e2ee/OlmAdapter.ts
@@ -323,14 +323,13 @@ export class OlmAdapter extends Listenable {
                     );
                     break;
                 case "e2ee.enabled":
-                    if (newValue) logger.info(
-                        `E2E: Participant ${participant.getId()} started encrypting their data.`,
-                    );
-                    /*if (newValue) {
-                        await this.initSessions();
-                    } else {
-                        this.clearParticipantSession(participant);
-                    }*/
+                    if (newValue) { logger.info(
+                        `E2E: Participant ${participant.getId()} STARTED encrypting data.`,
+                    );}
+                    else {
+                        logger.info(
+                            `E2E: Participant ${participant.getId()} STOPPED encrypting data.`);
+                    }
                     break;
             }
         }

--- a/modules/e2ee/OlmAdapter.ts
+++ b/modules/e2ee/OlmAdapter.ts
@@ -18,6 +18,7 @@ import {
     encryptKeyInfoPQ,
     generateKey,
     ratchet,
+    importKey,
 } from "./crypto-utils";
 import JitsiConference from "../../JitsiConference";
 import JitsiParticipant from "../../JitsiParticipant";
@@ -396,8 +397,10 @@ export class OlmAdapter extends Listenable {
      */
     async _ratchetKeyImpl() {
         try {
-            this._mediaKeyOlm = await ratchet(this._mediaKeyOlm);
-            this._mediaKeyPQ = await ratchet(this._mediaKeyPQ);
+            const materialOlm = await importKey(this._mediaKeyOlm);
+            const materialPQ = await importKey(this._mediaKeyPQ);
+            this._mediaKeyOlm = await ratchet(materialOlm);
+            this._mediaKeyPQ = await ratchet(materialPQ);
             this._mediaKeyIndex++;
             this.ratchetAllKeys();
         } catch (error) {

--- a/modules/e2ee/crypto-utils.ts
+++ b/modules/e2ee/crypto-utils.ts
@@ -50,12 +50,11 @@ export async function deriveKeys(
  * Ratchets a key.
  * See https://tools.ietf.org/html/draft-omara-sframe-00#section-4.3.5.1
  *
- * @param {Uint8Array} key - The input key.
+ * @param {CryptoKey} oldKey - The input key.
  * @returns {Promise<Uint8Array>} Ratched key.
  */
-export async function ratchet(keyBytes: Uint8Array): Promise<Uint8Array> {
+export async function ratchet(oldKey: CryptoKey): Promise<Uint8Array> {
     try {
-        const material = await importKey(keyBytes);
         const textEncoder = new TextEncoder();
         const key = await crypto.subtle.deriveBits(
             {
@@ -64,7 +63,7 @@ export async function ratchet(keyBytes: Uint8Array): Promise<Uint8Array> {
                 hash: HASH,
                 info: textEncoder.encode("JFrameInfo"),
             },
-            material,
+            oldKey,
             KEY_LEN,
         );
         return new Uint8Array(key);

--- a/modules/e2ee/crypto-utils.ts
+++ b/modules/e2ee/crypto-utils.ts
@@ -50,11 +50,12 @@ export async function deriveKeys(
  * Ratchets a key.
  * See https://tools.ietf.org/html/draft-omara-sframe-00#section-4.3.5.1
  *
- * @param {CryptoKey} oldKey - The input key.
+ * @param {Uint8Array} key - The input key.
  * @returns {Promise<Uint8Array>} Ratched key.
  */
-export async function ratchet(oldKey: CryptoKey): Promise<Uint8Array> {
+export async function ratchet(keyBytes: Uint8Array): Promise<Uint8Array> {
     try {
+        const material = await importKey(keyBytes);
         const textEncoder = new TextEncoder();
         const key = await crypto.subtle.deriveBits(
             {
@@ -63,7 +64,7 @@ export async function ratchet(oldKey: CryptoKey): Promise<Uint8Array> {
                 hash: HASH,
                 info: textEncoder.encode("JFrameInfo"),
             },
-            oldKey,
+            material,
             KEY_LEN,
         );
         return new Uint8Array(key);


### PR DESCRIPTION
- Remove initSessions from _onParticipantPropertyChanged. Instead, call _sendSessionInit(participant) when new participant joins
- Disable excessive debug logs 
- Clarify info messages

**Note:** Session timeout error is more likely. Until [fix_session_timeout_error](https://github.com/internxt/lib-jitsi-meet/tree/fix_session_timeout_error) PR is merged, it's harder to see the session establishment error. Hence, this fix is an upgrade of the previous PR and point to it.