### PR TITLE
[PB-3958] Fix E2E enabling after it was already enabled and disabled

### DIFF
--- a/modules/e2ee/ManagedKeyHandler.ts
+++ b/modules/e2ee/ManagedKeyHandler.ts
@@ -121,6 +121,7 @@ export class ManagedKeyHandler extends Listenable {
             logger.info("E2E: Enabling e2ee");
 
             this.enabled = true;
+            this._olmAdapter.generateNewKeys();
             const { olmKey, pqKey, index } = this._olmAdapter.getCurrentKeys();
             this.e2eeCtx.setKey(
                 this.conference.myUserId(),
@@ -130,15 +131,17 @@ export class ManagedKeyHandler extends Listenable {
             );
             await this._olmAdapter.initSessions();
 
-            this.conference.setLocalParticipantProperty("e2ee.enabled", true);
-            this.conference._restartMediaSessions();
         }
 
         if (!enabled) {
             logger.info("E2E: Disabling e2ee");
             this.enabled = false;
             this.e2eeCtx.cleanupAll();
+            this._olmAdapter.clearAllParticipantsSessions();
         }
+
+        this.conference.setLocalParticipantProperty("e2ee.enabled", enabled);
+        this.conference._restartMediaSessions();
     }
 
     /**


### PR DESCRIPTION
- call session clean up for all participants
- re-set protocol status 
- re-generate keys for each enable