### PR TITLE
[_] remove conference and eventEmitter from OlmAdapter

### DIFF
--- a/modules/e2ee/Constants.ts
+++ b/modules/e2ee/Constants.ts
@@ -1,32 +1,4 @@
 export const REQ_TIMEOUT = 20 * 1000;
-export const OLM_MESSAGE_TYPE = "olm";
-export const OLM_MESSAGE_TYPES = {
-    ERROR: "error",
-    KEY_INFO: "key-info",
-    SESSION_ACK: "session-ack",
-    PQ_SESSION_ACK: "pq-session-ack",
-    SESSION_INIT: "session-init",
-    PQ_SESSION_INIT: "pq-session-init",
-    SESSION_DONE: "session-done",
-};
-
-export const PROTOCOL_STATUS = {
-    TERMINATED: "protocol-terminated",
-    READY_TO_START: "ready-to-start",
-    WAITING_SESSION_ACK: "waiting-for-session-ack",
-    WAITING_PQ_SESSION_ACK: "waiting-for-pq-session-ack",
-    WAITING_PQ_SESSION_INIT: "waiting-for-pq-session-init",
-    WAITING_DONE: "waiting-for-done",
-    DONE: "protocol-established",
-};
-
-export const kOlmData = "OlmData";
-export const OlmAdapterEvents = {
-    PARTICIPANT_KEY_RATCHET: "olm.partitipant_key_ratchet",
-    PARTICIPANT_KEY_UPDATED: "olm.partitipant_key_updated",
-    PARTICIPANT_KEYS_COMMITMENT: "olm.participant_keys_committed",
-};
-
 export const IV_LENGTH = 16;
 export const MEDIA_KEY_LEN = 32;
 export const AUX = Uint8Array.from([

--- a/modules/e2ee/Constants.ts
+++ b/modules/e2ee/Constants.ts
@@ -20,6 +20,13 @@ export const PROTOCOL_STATUS = {
     DONE: "protocol-established",
 };
 
+export const kOlmData = "OlmData";
+export const OlmAdapterEvents = {
+    PARTICIPANT_KEY_RATCHET: "olm.partitipant_key_ratchet",
+    PARTICIPANT_KEY_UPDATED: "olm.partitipant_key_updated",
+    PARTICIPANT_KEYS_COMMITMENT: "olm.participant_keys_committed",
+};
+
 export const IV_LENGTH = 16;
 export const MEDIA_KEY_LEN = 32;
 export const AUX = Uint8Array.from([

--- a/modules/e2ee/E2EEContext.ts
+++ b/modules/e2ee/E2EEContext.ts
@@ -1,24 +1,6 @@
 /* global RTCRtpScriptTransform */
 import Listenable from "../util/Listenable";
-
-// Extend the RTCRtpReceiver interface due to lack of support of streams
-export interface CustomRTCRtpReceiver extends RTCRtpReceiver {
-    kJitsiE2EE: boolean;
-    createEncodedStreams?: () => {
-        readable: ReadableStream;
-        writable: WritableStream;
-    };
-    transform: RTCRtpScriptTransform;
-}
-
-export interface CustomRTCRtpSender extends RTCRtpSender {
-    kJitsiE2EE: boolean;
-    createEncodedStreams?: () => {
-        readable: ReadableStream;
-        writable: WritableStream;
-    };
-    transform: RTCRtpScriptTransform;
-}
+import { CustomRTCRtpReceiver, CustomRTCRtpSender } from "./Types";
 
 /**
  * Context encapsulating the cryptography bits required for E2EE.
@@ -201,9 +183,9 @@ export default class E2EEcontext extends Listenable {
      * Sets keys commitment for the specified participant.
      *
      * @param {string} participantId - The ID of the participant who's key we are setting.
-     * @param {Uint8Array} commitment - The commitment to the participant's identity keys.
+     * @param {string} commitment - The commitment to the participant's identity keys.
      */
-    setKeysCommitment(participantId: string, commitment: Uint8Array) {
+    setKeysCommitment(participantId: string, commitment: string) {
         this._worker.postMessage({
             operation: "setKeysCommitment",
             commitment,

--- a/modules/e2ee/ManagedKeyHandler.ts
+++ b/modules/e2ee/ManagedKeyHandler.ts
@@ -4,10 +4,7 @@ import browser from "../browser";
 import JitsiLocalTrack from "../RTC/JitsiLocalTrack";
 import JingleSessionPC from "../xmpp/JingleSessionPC";
 import TraceablePeerConnection from "../RTC/TraceablePeerConnection";
-import E2EEContext, {
-    CustomRTCRtpReceiver,
-    CustomRTCRtpSender,
-} from "./E2EEContext";
+import E2EEContext from "./E2EEContext";
 
 import * as JitsiConferenceEvents from "../../JitsiConferenceEvents";
 import JitsiParticipant from "../../JitsiParticipant";
@@ -18,6 +15,27 @@ import JitsiConference from "../../JitsiConference";
 import RTCEvents from "../../service/RTC/RTCEvents";
 import { generateEmojiSas } from "./crypto-workers";
 
+import { JITSI_MEET_MUC_TYPE, FEATURE_E2EE } from "../xmpp/xmpp";
+import { REQ_TIMEOUT } from "./Constants";
+import {
+    OLM_MESSAGE_TYPE,
+    OLM_MESSAGE_TYPES,
+    MessageType,
+    CustomRTCRtpReceiver,
+    CustomRTCRtpSender,
+    ReplyMessage,
+    SessionError,
+} from "./Types";
+
+function timeout<T>(ms: number): Promise<T> {
+    return new Promise((_, reject) =>
+        setTimeout(
+            () => reject(new Error("Session init request timed out")),
+            ms,
+        ),
+    );
+}
+
 /**
  * This module integrates {@link E2EEContext} with {@link OlmAdapter} in order to distribute the keys for encryption.
  */
@@ -25,9 +43,13 @@ export class ManagedKeyHandler extends Listenable {
     conference: JitsiConference;
     e2eeCtx: E2EEContext;
     enabled: boolean;
-    init: Promise<Promise<unknown>[]>;
+    initSessions: Promise<unknown[]>;
     _olmAdapter: OlmAdapter;
     private _conferenceJoined: boolean;
+    private readonly _reqs: Map<
+        string,
+        { resolve: (args?: unknown) => void; reject?: (args?: unknown) => void }
+    >;
 
     /**
      * Build a new AutomaticKeyHandler instance, which will be used in a given conference.
@@ -36,6 +58,7 @@ export class ManagedKeyHandler extends Listenable {
         super();
         this.conference = conference;
         this.e2eeCtx = new E2EEContext();
+        this._reqs = new Map();
 
         this.enabled = false;
 
@@ -79,23 +102,7 @@ export class ManagedKeyHandler extends Listenable {
 
         this._conferenceJoined = false;
 
-        this._olmAdapter = new OlmAdapter(conference);
-
-        // Olm signalling events.
-        this._olmAdapter.on(
-            OlmAdapter.events.PARTICIPANT_KEY_UPDATED,
-            this._onParticipantKeyUpdated.bind(this),
-        );
-
-        this._olmAdapter.on(
-            OlmAdapter.events.PARTICIPANT_KEYS_COMMITMENT,
-            this._onParticipantKeysCommitted.bind(this),
-        );
-
-        this._olmAdapter.on(
-            OlmAdapter.events.PARTICIPANT_KEY_RATCHET,
-            this._onParticipantKeyRatchet.bind(this),
-        );
+        this._olmAdapter = new OlmAdapter(conference.myUserId());
 
         this.e2eeCtx.on("sasUpdated", (sasStr: string) => {
             (async () => {
@@ -107,6 +114,9 @@ export class ManagedKeyHandler extends Listenable {
                 );
             })();
         });
+    }
+    async init() {
+        await this._olmAdapter.init();
     }
 
     /**
@@ -128,22 +138,20 @@ export class ManagedKeyHandler extends Listenable {
         if (enabled === this.enabled) {
             return;
         }
+        this.enabled = enabled;
+
+        if (!this._olmAdapter.isInitialized()) {
+            await this._olmAdapter.init();
+        }
 
         if (enabled) {
             console.info("E2E: Enabling e2ee");
-            this.enabled = true;
-
-            await this._olmAdapter.init();
-            this.init = this._olmAdapter.initSessions();
-            await this.init;
+            this.enableE2E();
         }
 
         if (!enabled) {
             console.info("E2E: Disabling e2ee");
-            this.enabled = false;
-
-            this.e2eeCtx.cleanupAll();
-            this._olmAdapter.clearAllParticipantsSessions();
+            this.disableE2E();
         }
 
         this.conference.setLocalParticipantProperty("e2ee.enabled", enabled);
@@ -171,6 +179,79 @@ export class ManagedKeyHandler extends Listenable {
 
         for (const track of localTracks) {
             this._setupSenderE2EEForTrack(session, track);
+        }
+    }
+
+    /**
+     * Enables End-To-End encryption.
+     */
+    async enableE2E() {
+        const localParticipantId = this.conference.myUserId();
+        const keyCommitment = this._olmAdapter.getMyIdentityKeysCommitment();
+        this.e2eeCtx.setKeysCommitment(localParticipantId, keyCommitment);
+        const { olmKey, pqKey, index } = this._olmAdapter.updateMyKeys();
+        this.setKey(olmKey, pqKey, index);
+
+        const participants = this.conference.getParticipants();
+        const list = participants.filter(
+            (participant) =>
+                participant.hasFeature(FEATURE_E2EE) &&
+                localParticipantId > participant.getId(),
+        );
+        const keys = this._olmAdapter.generateOneTimeKeys(list.length);
+        console.info(
+            `E2E: My ID is ${localParticipantId}, should send session-init to smaller IDs: [ ${list.map((p) => p.getId())}]`,
+        );
+
+        this.initSessions = (async () => {
+            const promises = list.map(async (participant) => {
+                const pId = participant.getId();
+                try {
+                    const lastKey = keys.pop();
+                    const data =
+                        await this._olmAdapter.createSessionInitMessage(
+                            pId,
+                            lastKey,
+                        );
+                    this._sendMessage(
+                        OLM_MESSAGE_TYPES.SESSION_INIT,
+                        data,
+                        pId,
+                    );
+
+                    const sessionPromise = new Promise((resolve, reject) => {
+                        this._reqs.set(pId, { resolve, reject });
+                    });
+
+                    const result = await Promise.race([
+                        sessionPromise,
+                        timeout(REQ_TIMEOUT),
+                    ]);
+                    console.info(
+                        `E2E: Session with ${pId} initialized successfully.`,
+                    );
+                    return result;
+                } catch (error) {
+                    console.error(
+                        `E2E: Failed to initialize session with ${pId}: ${error}`,
+                    );
+                    this._reqs.delete(pId);
+                    throw error;
+                }
+            });
+
+            return Promise.all(promises);
+        })();
+        await this.initSessions;
+    }
+    /**
+     * Disables End-To-End encryption.
+     */
+    async disableE2E() {
+        this.e2eeCtx.cleanupAll();
+        const participants = this.conference.getParticipants();
+        for (const participant of participants) {
+            this._olmAdapter.clearParticipantSession(participant.getId());
         }
     }
 
@@ -253,11 +334,22 @@ export class ManagedKeyHandler extends Listenable {
      * @private
      */
     async _onParticipantJoined(id: string) {
-        console.info(`E2E: A new participant ${id} joined the conference`);
-        if (this._conferenceJoined && this.enabled) {
-            await this._olmAdapter.init();
-            await this.init;
-            await this._olmAdapter._ratchetKeyImpl();
+        console.info(`E2E: Participant ${id} joined the conference.`);
+        if (
+            this._conferenceJoined &&
+            this.enabled &&
+            this._olmAdapter.isInitialized()
+        ) {
+            const participants = this.conference.getParticipants();
+            const { olmKey, pqKey, index } =
+                await this._olmAdapter.ratchetMyKeys();
+            this.setKey(olmKey, pqKey, index);
+            for (const participant of participants) {
+                const pId = participant.getId();
+                if (this._olmAdapter.checkIfShouldRatchetParticipantKey(pId)) {
+                    this.e2eeCtx.ratchetKeys(pId);
+                }
+            }
         }
     }
 
@@ -265,23 +357,183 @@ export class ManagedKeyHandler extends Listenable {
      * Rotates the current key when a participant leaves the conference.
      * @private
      */
-    async _onParticipantLeft(id: string, participant: JitsiParticipant) {
-        console.info(`E2E: Participant ${id} left the conference.`);
-        if (this.enabled) {
-            await this._olmAdapter.init();
-            await this.init;
-            this._olmAdapter.clearParticipantSession(participant);
-            this.e2eeCtx.cleanup(id);
-            this._olmAdapter._rotateKeyImpl();
+    async _onParticipantLeft(pId: string) {
+        console.info(`E2E: Participant ${pId} left the conference.`);
+        if (this.enabled && this._olmAdapter.isInitialized()) {
+            //await this.initSessions;
+            this._olmAdapter.clearParticipantSession(pId);
+            this.e2eeCtx.cleanup(pId);
+            const { olmKey, pqKey, index } = this._olmAdapter.updateMyKeys();
+            this.setKey(olmKey, pqKey, index);
+            const participants = this.conference.getParticipants();
+            for (const participant of participants) {
+                const pId = participant.getId();
+                const data =
+                    await this._olmAdapter.checkIfShouldSendKeyInfoToParticipant(
+                        pId,
+                    );
+                if (data) {
+                    this._sendMessage(OLM_MESSAGE_TYPES.KEY_INFO, data, pId);
+                }
+            }
         }
     }
 
     async _onConferenceLeft() {
-        this._olmAdapter._onConferenceLeft();
+        const participants = this.conference.getParticipants();
+        this._olmAdapter._onConferenceLeft(participants);
     }
 
     async _onEndpointMessageReceived(participant: JitsiParticipant, payload) {
-        this._olmAdapter._onEndpointMessageReceived(participant, payload);
+        try {
+            if (
+                payload[JITSI_MEET_MUC_TYPE] !== OLM_MESSAGE_TYPE ||
+                !payload.olm
+            ) {
+                console.warn("E2E: Invalid or missing olm payload");
+                return;
+            }
+            if (!this._olmAdapter.isInitialized()) {
+                throw new Error("Olm not initialized");
+            }
+
+            const msg = payload.olm;
+            const pId = participant.getId();
+
+            switch (msg.type) {
+                case OLM_MESSAGE_TYPES.SESSION_INIT: {
+                    const { otKey, publicKey, publicKyberKey, commitment } =
+                        msg.data;
+                    const { data, keyCommitment } =
+                        await this._olmAdapter.createPQsessionInitMessage(
+                            pId,
+                            otKey,
+                            publicKey,
+                            publicKyberKey,
+                            commitment,
+                        );
+                    this.e2eeCtx.setKeysCommitment(pId, keyCommitment);
+                    this._sendMessage(
+                        OLM_MESSAGE_TYPES.PQ_SESSION_INIT,
+                        data,
+                        pId,
+                    );
+                    break;
+                }
+
+                case OLM_MESSAGE_TYPES.PQ_SESSION_INIT: {
+                    const {
+                        encapsKyber,
+                        publicKey,
+                        publicKyberKey,
+                        ciphertext,
+                        message_type,
+                    } = msg.data;
+                    const { data, keyCommitment } =
+                        await this._olmAdapter.createPQsessionAckMessage(
+                            pId,
+                            encapsKyber,
+                            publicKey,
+                            publicKyberKey,
+                            ciphertext,
+                            message_type,
+                        );
+                    this.e2eeCtx.setKeysCommitment(pId, keyCommitment);
+                    this._sendMessage(
+                        OLM_MESSAGE_TYPES.PQ_SESSION_ACK,
+                        data,
+                        pId,
+                    );
+                    break;
+                }
+                case OLM_MESSAGE_TYPES.PQ_SESSION_ACK: {
+                    const {
+                        encapsKyber,
+                        ciphertext,
+                        message_type,
+                        pqCiphertext,
+                    } = msg.data;
+
+                    const { data, olmKey, pqKey, index } =
+                        await this._olmAdapter.createSessionAckMessage(
+                            pId,
+                            encapsKyber,
+                            ciphertext,
+                            message_type,
+                            pqCiphertext,
+                        );
+                    this._onParticipantKeyUpdated(pId, olmKey, pqKey, index);
+                    this._sendMessage(OLM_MESSAGE_TYPES.SESSION_ACK, data, pId);
+                    break;
+                }
+                case OLM_MESSAGE_TYPES.SESSION_ACK: {
+                    const { ciphertext, message_type, pqCiphertext } = msg.data;
+
+                    const { data, olmKey, pqKey, index } =
+                        await this._olmAdapter.createSessionDoneMessage(
+                            pId,
+                            ciphertext,
+                            message_type,
+                            pqCiphertext,
+                        );
+                    this._onParticipantKeyUpdated(pId, olmKey, pqKey, index);
+                    this._sendMessage(OLM_MESSAGE_TYPES.SESSION_DONE, "", pId);
+                    if (data) {
+                        this._sendMessage(
+                            OLM_MESSAGE_TYPES.KEY_INFO,
+                            data,
+                            pId,
+                        );
+                    }
+                    const requestPromise = this._reqs.get(pId);
+                    if (requestPromise) {
+                        requestPromise.resolve();
+                        this._reqs.delete(pId);
+                    } else
+                        console.warn(
+                            `E2E: Session with ${pId} was established after reaching time out.`,
+                        );
+                    break;
+                }
+                case OLM_MESSAGE_TYPES.ERROR: {
+                    console.error(msg.data.error);
+                    break;
+                }
+                case OLM_MESSAGE_TYPES.SESSION_DONE: {
+                    console.info(`E2E: Recived SESSION_DONE message.`);
+                    const data =
+                        await this._olmAdapter.processSessionDoneMessage(pId);
+                    if (data) {
+                        this._sendMessage(
+                            OLM_MESSAGE_TYPES.KEY_INFO,
+                            data,
+                            pId,
+                        );
+                    }
+                    break;
+                }
+                case OLM_MESSAGE_TYPES.KEY_INFO: {
+                    const { ciphertext, message_type, pqCiphertext } = msg.data;
+                    const { olmKey, pqKey, index } =
+                        await this._olmAdapter.processKeyInfoMessage(
+                            pId,
+                            ciphertext,
+                            message_type,
+                            pqCiphertext,
+                        );
+                    this._onParticipantKeyUpdated(pId, olmKey, pqKey, index);
+                    break;
+                }
+            }
+        } catch (error) {
+            const data: SessionError = { error };
+            console.log(`E2E: Error processing message: ${error}`);
+            this._sendMessage(
+                OLM_MESSAGE_TYPES.ERROR,
+                data,
+                participant.getId(),
+            );
+        }
     }
 
     /**
@@ -314,23 +566,25 @@ export class ManagedKeyHandler extends Listenable {
     }
 
     /**
-     * Updates a participant's key.
+     * Internal helper to send the given object to the given participant ID.
+     * This function merely exists so the transport can be easily swapped.
+     * Currently messages are transmitted via XMPP MUC private messages.
      *
-     * @param {string} id - The participant ID.
-     * @param {Uint8Array} commitment - The commitment to participant's identity keys.
-     * @private
+     * @param {object} data - The data that will be sent to the target participant.
+     * @param {string} participantId - ID of the target participant.
      */
-    _onParticipantKeysCommitted(id: string, commitment: Uint8Array) {
-        this.e2eeCtx.setKeysCommitment(id, commitment);
-    }
-
-    /**
-     * Ratchets a participant's key.
-     *
-     * @param {string} id - The participant ID.
-     * @private
-     */
-    _onParticipantKeyRatchet(id: string) {
-        this.e2eeCtx.ratchetKeys(id);
+    _sendMessage(
+        type: MessageType,
+        data: ReplyMessage | "",
+        participantId: string,
+    ) {
+        const msg = {
+            [JITSI_MEET_MUC_TYPE]: OLM_MESSAGE_TYPE,
+            olm: {
+                type,
+                data,
+            },
+        };
+        this.conference.sendMessage(msg, participantId);
     }
 }

--- a/modules/e2ee/ManagedKeyHandler.ts
+++ b/modules/e2ee/ManagedKeyHandler.ts
@@ -429,7 +429,6 @@ export class ManagedKeyHandler extends Listenable {
                         publicKey,
                         publicKyberKey,
                         ciphertext,
-                        message_type,
                     } = msg.data;
                     const { data, keyCommitment } =
                         await this._olmAdapter.createPQsessionAckMessage(
@@ -438,7 +437,6 @@ export class ManagedKeyHandler extends Listenable {
                             publicKey,
                             publicKyberKey,
                             ciphertext,
-                            message_type,
                         );
                     this.e2eeCtx.setKeysCommitment(pId, keyCommitment);
                     this._sendMessage(
@@ -449,19 +447,13 @@ export class ManagedKeyHandler extends Listenable {
                     break;
                 }
                 case OLM_MESSAGE_TYPES.PQ_SESSION_ACK: {
-                    const {
-                        encapsKyber,
-                        ciphertext,
-                        message_type,
-                        pqCiphertext,
-                    } = msg.data;
+                    const { encapsKyber, ciphertext, pqCiphertext } = msg.data;
 
                     const { data, olmKey, pqKey, index } =
                         await this._olmAdapter.createSessionAckMessage(
                             pId,
                             encapsKyber,
                             ciphertext,
-                            message_type,
                             pqCiphertext,
                         );
                     this.updateParticipantKey(pId, olmKey, pqKey, index);
@@ -469,13 +461,12 @@ export class ManagedKeyHandler extends Listenable {
                     break;
                 }
                 case OLM_MESSAGE_TYPES.SESSION_ACK: {
-                    const { ciphertext, message_type, pqCiphertext } = msg.data;
+                    const { ciphertext, pqCiphertext } = msg.data;
 
                     const { data, olmKey, pqKey, index } =
                         await this._olmAdapter.createSessionDoneMessage(
                             pId,
                             ciphertext,
-                            message_type,
                             pqCiphertext,
                         );
                     this.updateParticipantKey(pId, olmKey, pqKey, index);
@@ -515,12 +506,11 @@ export class ManagedKeyHandler extends Listenable {
                     break;
                 }
                 case OLM_MESSAGE_TYPES.KEY_INFO: {
-                    const { ciphertext, message_type, pqCiphertext } = msg.data;
+                    const { ciphertext, pqCiphertext } = msg.data;
                     const { olmKey, pqKey, index } =
                         await this._olmAdapter.processKeyInfoMessage(
                             pId,
                             ciphertext,
-                            message_type,
                             pqCiphertext,
                         );
                     this.updateParticipantKey(pId, olmKey, pqKey, index);

--- a/modules/e2ee/ManagedKeyHandler.ts
+++ b/modules/e2ee/ManagedKeyHandler.ts
@@ -236,7 +236,6 @@ export class ManagedKeyHandler extends Listenable {
                         `E2E: Failed to initialize session with ${pId}: ${error}`,
                     );
                     this._reqs.delete(pId);
-                    throw error;
                 }
             });
 
@@ -357,12 +356,12 @@ export class ManagedKeyHandler extends Listenable {
      * Rotates the current key when a participant leaves the conference.
      * @private
      */
-    async _onParticipantLeft(pId: string) {
-        console.info(`E2E: Participant ${pId} left the conference.`);
+    async _onParticipantLeft(id: string) {
+        console.info(`E2E: Participant ${id} left the conference.`);
         if (this.enabled && this._olmAdapter.isInitialized()) {
-            //await this.initSessions;
-            this._olmAdapter.clearParticipantSession(pId);
-            this.e2eeCtx.cleanup(pId);
+            await this.initSessions;
+            this._olmAdapter.clearParticipantSession(id);
+            this.e2eeCtx.cleanup(id);
             const { olmKey, pqKey, index } = this._olmAdapter.updateMyKeys();
             this.setKey(olmKey, pqKey, index);
             const participants = this.conference.getParticipants();

--- a/modules/e2ee/OlmAdapter.ts
+++ b/modules/e2ee/OlmAdapter.ts
@@ -3,7 +3,6 @@ import initVodozemac, {
     Session,
     EncryptedOlmMessage,
 } from "vodozemac-wasm";
-
 import {
     generateKyberKeys,
     encapsulateSecret,
@@ -18,7 +17,6 @@ import {
     deriveEncryptionKey,
     commitToMediaKeyShares,
 } from "./crypto-workers";
-import JitsiParticipant from "../../JitsiParticipant";
 import {
     PROTOCOL_STATUS,
     ProtocolStatus,
@@ -273,11 +271,7 @@ export class OlmAdapter {
         return result;
     }
 
-    async _onConferenceLeft(participants: JitsiParticipant[]) {
-        for (const participant of participants) {
-            this.clearParticipantSession(participant.getId());
-        }
-
+    async clearMySession() {
         if (this._olmAccount) {
             this._olmAccount.free();
             this._olmAccount = undefined;

--- a/modules/e2ee/OlmAdapter.ts
+++ b/modules/e2ee/OlmAdapter.ts
@@ -247,12 +247,12 @@ export class OlmAdapter {
     clearParticipantSession(pId: string) {
         try {
             const olmData = this._getParticipantOlmData(pId);
+            olmData.status = PROTOCOL_STATUS.TERMINATED;
 
             if (olmData.session) {
                 olmData.session.free();
                 olmData.session = undefined;
             }
-            olmData.status = PROTOCOL_STATUS.TERMINATED;
         } catch (error) {
             console.error(
                 `E2E: Failed to clear session for participat ${pId}: ${error}`,

--- a/modules/e2ee/Types.ts
+++ b/modules/e2ee/Types.ts
@@ -1,0 +1,89 @@
+export const OLM_MESSAGE_TYPE = "olm";
+export const OLM_MESSAGE_TYPES = {
+    ERROR: "error",
+    KEY_INFO: "key-info",
+    SESSION_ACK: "session-ack",
+    PQ_SESSION_ACK: "pq-session-ack",
+    SESSION_INIT: "session-init",
+    PQ_SESSION_INIT: "pq-session-init",
+    SESSION_DONE: "session-done",
+};
+export type MessageType =
+    (typeof OLM_MESSAGE_TYPES)[keyof typeof OLM_MESSAGE_TYPES];
+
+export const PROTOCOL_STATUS = {
+    TERMINATED: "protocol-terminated",
+    READY_TO_START: "ready-to-start",
+    WAITING_SESSION_ACK: "waiting-for-session-ack",
+    WAITING_PQ_SESSION_ACK: "waiting-for-pq-session-ack",
+    WAITING_PQ_SESSION_INIT: "waiting-for-pq-session-init",
+    WAITING_DONE: "waiting-for-done",
+    DONE: "protocol-established",
+};
+
+export type ProtocolStatus =
+    (typeof PROTOCOL_STATUS)[keyof typeof PROTOCOL_STATUS];
+
+// Extend the RTCRtpReceiver interface due to lack of support of streams
+export interface CustomRTCRtpReceiver extends RTCRtpReceiver {
+    kJitsiE2EE: boolean;
+    createEncodedStreams?: () => {
+        readable: ReadableStream;
+        writable: WritableStream;
+    };
+    transform: RTCRtpScriptTransform;
+}
+
+export interface CustomRTCRtpSender extends RTCRtpSender {
+    kJitsiE2EE: boolean;
+    createEncodedStreams?: () => {
+        readable: ReadableStream;
+        writable: WritableStream;
+    };
+    transform: RTCRtpScriptTransform;
+}
+
+export type ReplyMessage =
+    | KeyInfo
+    | SessionInit
+    | PQsessionInit
+    | PQsessionAck
+    | SessionAck
+    | SessionError;
+
+export type KeyInfo = {
+    ciphertext: string;
+    message_type: number;
+    pqCiphertext: string;
+};
+
+export type SessionInit = {
+    otKey: string;
+    publicKey: string;
+    publicKyberKey: string;
+    commitment: string;
+};
+export type PQsessionAck = {
+    encapsKyber: string;
+    ciphertext: string;
+    message_type: number;
+    pqCiphertext: string;
+};
+
+export type PQsessionInit = {
+    encapsKyber: string;
+    publicKey: string;
+    publicKyberKey: string;
+    ciphertext: string;
+    message_type: number;
+};
+
+export type SessionAck = {
+    ciphertext: string;
+    message_type: number;
+    pqCiphertext: string;
+};
+
+export type SessionError = {
+    error: string;
+};

--- a/modules/e2ee/Types.ts
+++ b/modules/e2ee/Types.ts
@@ -1,3 +1,7 @@
+//vodozemac message types
+export const PREKEY_MESSAGE = 0;
+export const NORMAL_MESSAGE = 1;
+
 export const OLM_MESSAGE_TYPE = "olm";
 export const OLM_MESSAGE_TYPES = {
     ERROR: "error",
@@ -53,7 +57,6 @@ export type ReplyMessage =
 
 export type KeyInfo = {
     ciphertext: string;
-    message_type: number;
     pqCiphertext: string;
 };
 
@@ -66,7 +69,6 @@ export type SessionInit = {
 export type PQsessionAck = {
     encapsKyber: string;
     ciphertext: string;
-    message_type: number;
     pqCiphertext: string;
 };
 
@@ -75,12 +77,10 @@ export type PQsessionInit = {
     publicKey: string;
     publicKyberKey: string;
     ciphertext: string;
-    message_type: number;
 };
 
 export type SessionAck = {
     ciphertext: string;
-    message_type: number;
     pqCiphertext: string;
 };
 


### PR DESCRIPTION
OlmAdapter used to have an instance of JitsiConference for accessing IDs and participants and sending messages. It also emitted signals to its parent class, ManagedKeyHandler. Both of those things make test writing hard. 

This PR ensures that only ManagedKeyHandler interacts with JitsiConference.