### PR TITLE
[_] Remove selection for video unencrypted bytes

### DIFF
--- a/modules/e2ee/Constants.ts
+++ b/modules/e2ee/Constants.ts
@@ -1,11 +1,11 @@
 export const REQ_TIMEOUT = 20 * 1000;
 export const IV_LENGTH = 16;
-export const MEDIA_KEY_LEN = 32;
 export const AUX = Uint8Array.from([
     80, 81, 32, 75, 101, 121, 32, 73, 110, 102, 111,
 ]); // "PQ Key Info"
 export const AES = "AES-GCM";
 export const AES_KEY_LEN = 256;
+export const MEDIA_KEY_LEN = AES_KEY_LEN/8;
 export const HASH_LEN = 256;
 
 // We use a ringbuffer of keys so we can change them and still decode packets that were
@@ -19,7 +19,7 @@ export const KEYRING_SIZE = 16;
 //
 // For audio (where frame.type is not set) we do not encrypt the opus TOC byte:
 //   https://tools.ietf.org/html/rfc6716#section-3.1
-export const UNENCRYPTED_BYTES = 1;
+export const UNENCRYPTED_BYTES_NUMBER = 1;
 
 export const SAS_LEN = 48;
 

--- a/modules/e2ee/Constants.ts
+++ b/modules/e2ee/Constants.ts
@@ -14,19 +14,12 @@ export const HASH_LEN = 256;
 export const KEYRING_SIZE = 16;
 
 // We copy the first bytes of the VP8 payload unencrypted.
-// For keyframes this is 10 bytes, for non-keyframes (delta) 3. See
-//   https://tools.ietf.org/html/rfc6386#section-9.1
 // This allows the bridge to continue detecting keyframes (only one byte needed in the JVB)
-// and is also a bit easier for the VP8 decoder (i.e. it generates funny garbage pictures
-// instead of being unable to decode).
-// This is a bit for show and we might want to reduce to 1 unconditionally in the final version.
+//    https://tools.ietf.org/html/rfc6386#section-9.1
 //
 // For audio (where frame.type is not set) we do not encrypt the opus TOC byte:
 //   https://tools.ietf.org/html/rfc6716#section-3.1
-export const VIDEO_UNENCRYPTED_BYTES = {
-    key: 10,
-    delta: 3,
-};
+export const UNENCRYPTED_BYTES = 1;
 
 export const SAS_LEN = 48;
 

--- a/modules/e2ee/Context.ts
+++ b/modules/e2ee/Context.ts
@@ -7,7 +7,7 @@ import {
     logError,
     logInfo,
 } from "./crypto-workers";
-import { KEYRING_SIZE, UNENCRYPTED_BYTES, IV_LENGTH } from "./Constants";
+import { KEYRING_SIZE, UNENCRYPTED_BYTES_NUMBER, IV_LENGTH } from "./Constants";
 
 let printEncStart = true;
 
@@ -127,7 +127,7 @@ export class Context {
             const frameHeader = new Uint8Array(
                 encodedFrame.data,
                 0,
-                UNENCRYPTED_BYTES,
+                UNENCRYPTED_BYTES_NUMBER,
             );
 
             // Construct frame trailer. Similar to the frame header described in
@@ -139,29 +139,29 @@ export class Context {
             // ---------+-------------------------+-+---------+----
             const data: Uint8Array = new Uint8Array(
                 encodedFrame.data,
-                UNENCRYPTED_BYTES,
+                UNENCRYPTED_BYTES_NUMBER,
             );
             const additionalData = new Uint8Array(
                 encodedFrame.data,
                 0,
-                UNENCRYPTED_BYTES,
+                UNENCRYPTED_BYTES_NUMBER,
             );
             const cipherText = await encryptData(iv, additionalData, key, data);
 
             const newData = new ArrayBuffer(
-                UNENCRYPTED_BYTES + cipherText.byteLength + IV_LENGTH + 1,
+                UNENCRYPTED_BYTES_NUMBER + cipherText.byteLength + IV_LENGTH + 1,
             );
             const newUint8 = new Uint8Array(newData);
 
             newUint8.set(frameHeader); // copy first bytes.
-            newUint8.set(new Uint8Array(cipherText), UNENCRYPTED_BYTES); // add ciphertext.
+            newUint8.set(new Uint8Array(cipherText), UNENCRYPTED_BYTES_NUMBER); // add ciphertext.
             newUint8.set(
                 new Uint8Array(iv),
-                UNENCRYPTED_BYTES + cipherText.byteLength,
+                UNENCRYPTED_BYTES_NUMBER + cipherText.byteLength,
             ); // append IV.
             newUint8.set(
                 new Uint8Array([keyIndex]),
-                UNENCRYPTED_BYTES + cipherText.byteLength + IV_LENGTH,
+                UNENCRYPTED_BYTES_NUMBER + cipherText.byteLength + IV_LENGTH,
             ); // append frame trailer.
             encodedFrame.data = newData;
             if (printEncStart) {
@@ -218,16 +218,16 @@ export class Context {
 
             const cipherTextLength =
                 encodedFrame.data.byteLength -
-                (UNENCRYPTED_BYTES + IV_LENGTH + 1);
+                (UNENCRYPTED_BYTES_NUMBER + IV_LENGTH + 1);
 
             const additionalData = new Uint8Array(
                 encodedFrame.data,
                 0,
-                UNENCRYPTED_BYTES,
+                UNENCRYPTED_BYTES_NUMBER,
             );
             const data = new Uint8Array(
                 encodedFrame.data,
-                UNENCRYPTED_BYTES,
+                UNENCRYPTED_BYTES_NUMBER,
                 cipherTextLength,
             );
             const plainText = await decryptData(
@@ -238,14 +238,14 @@ export class Context {
             );
 
             const newData = new ArrayBuffer(
-                UNENCRYPTED_BYTES + plainText.byteLength,
+                UNENCRYPTED_BYTES_NUMBER + plainText.byteLength,
             );
             const newUint8 = new Uint8Array(newData);
 
             newUint8.set(
-                new Uint8Array(encodedFrame.data, 0, UNENCRYPTED_BYTES),
+                new Uint8Array(encodedFrame.data, 0, UNENCRYPTED_BYTES_NUMBER),
             );
-            newUint8.set(new Uint8Array(plainText), UNENCRYPTED_BYTES);
+            newUint8.set(new Uint8Array(plainText), UNENCRYPTED_BYTES_NUMBER);
 
             encodedFrame.data = newData;
 

--- a/modules/e2ee/ManagedKeyHandler.ts
+++ b/modules/e2ee/ManagedKeyHandler.ts
@@ -1,3 +1,5 @@
+/// <reference types="node" />
+
 import browser from "../browser";
 import JitsiLocalTrack from "../RTC/JitsiLocalTrack";
 import JingleSessionPC from "../xmpp/JingleSessionPC";
@@ -117,6 +119,9 @@ export class ManagedKeyHandler extends Listenable {
                 );
             })();
         });
+    }
+    async init() {
+        await this._olmAdapter.init();
     }
 
     /**
@@ -327,6 +332,7 @@ export class ManagedKeyHandler extends Listenable {
 
     /**
      * Advances (using ratcheting) the current key when a new participant joins the conference.
+     * Sends a session-init to a new participant if their ID is bigger than ID of this user.
      *
      * @private
      */

--- a/modules/e2ee/ManagedKeyHandler.ts
+++ b/modules/e2ee/ManagedKeyHandler.ts
@@ -1,5 +1,3 @@
-/// <reference types="node" />
-
 import browser from "../browser";
 import JitsiLocalTrack from "../RTC/JitsiLocalTrack";
 import JingleSessionPC from "../xmpp/JingleSessionPC";
@@ -119,9 +117,6 @@ export class ManagedKeyHandler extends Listenable {
                 );
             })();
         });
-    }
-    async init() {
-        await this._olmAdapter.init();
     }
 
     /**
@@ -332,7 +327,6 @@ export class ManagedKeyHandler extends Listenable {
 
     /**
      * Advances (using ratcheting) the current key when a new participant joins the conference.
-     * Sends a session-init to a new participant if their ID is bigger than ID of this user.
      *
      * @private
      */

--- a/modules/e2ee/crypto-workers.ts
+++ b/modules/e2ee/crypto-workers.ts
@@ -7,6 +7,7 @@ import {
     RATCHET_CONTEXT,
     DERIVE_CONTEXT,
     MEDIA_KEY_COMMITMENT_PREFIX,
+    IDENTITY_KEYS_PREFIX,
     KEY_HASH_PREFIX,
 } from "./Constants";
 import { emojiMapping } from "./SAS";
@@ -195,7 +196,7 @@ export async function commitToIdentityKeys(
     publicKey: string,
 ): Promise<string> {
     return computeHash(
-        MEDIA_KEY_COMMITMENT_PREFIX,
+        IDENTITY_KEYS_PREFIX,
         participantID,
         publicKyberKey,
         publicKey,


### PR DESCRIPTION
Jitsi did it to show visual effects. Then, the auditors published a paper saying it's bad for privacy. Jitsi stopped. 

Anyway, for video management, the Jitsi server needs 1 byte; no need to do different numbers of bytes for different frames. 

IV_LENGTH is a fixed constant; no need to send it with _each_ frame