### PR TITLE
[_] Fix rare missing ratcher error

### DIFF
--- a/modules/e2ee/Context.ts
+++ b/modules/e2ee/Context.ts
@@ -149,7 +149,10 @@ export class Context {
             const cipherText = await encryptData(iv, additionalData, key, data);
 
             const newData = new ArrayBuffer(
-                UNENCRYPTED_BYTES_NUMBER + cipherText.byteLength + IV_LENGTH + 1,
+                UNENCRYPTED_BYTES_NUMBER +
+                    cipherText.byteLength +
+                    IV_LENGTH +
+                    1,
             );
             const newUint8 = new Uint8Array(newData);
 

--- a/modules/e2ee/ManagedKeyHandler.ts
+++ b/modules/e2ee/ManagedKeyHandler.ts
@@ -337,7 +337,6 @@ export class ManagedKeyHandler extends Listenable {
 
     /**
      * Advances (using ratcheting) the current key when a new participant joins the conference.
-     * Sends a session-init to a new participant if their ID is bigger than ID of this user.
      *
      * @private
      */

--- a/modules/e2ee/Types.ts
+++ b/modules/e2ee/Types.ts
@@ -6,6 +6,7 @@ export const OLM_MESSAGE_TYPE = "olm";
 export const OLM_MESSAGE_TYPES = {
     ERROR: "error",
     KEY_INFO: "key-info",
+    KEY_UPDATED: "key-updated",
     SESSION_ACK: "session-ack",
     PQ_SESSION_ACK: "pq-session-ack",
     SESSION_INIT: "session-init",

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -46,6 +46,8 @@ describe("Test E2E:", () => {
         async () => {
             const context1 = new E2EEContext();
             const context2 = new E2EEContext();
+            context1.setKeysCommitment("participant1", "commitment1");
+            context2.setKeysCommitment("participant2", "commitment2");
 
             const contextSpy1 = spy(context1);
             const contextSpy2 = spy(context2);
@@ -62,7 +64,7 @@ describe("Test E2E:", () => {
             verify((contextSpy2 as any).updateSAS(anything())).called();
         },
         MAX_TEST_TIME,
-    ); 
+    );
 
     /**
      * Verifies that participant recived and processed e2e channel establishement request
@@ -175,7 +177,10 @@ describe("Test E2E:", () => {
         const userData: UserData[] = [];
 
         for (let i = 0; i < participantCount; i++) {
-            const { id, keyHandler } = await createInitializedManagedKeyHandler(xmppServerMock, TEST_TIMEOUT);
+            const { id, keyHandler } = await createInitializedManagedKeyHandler(
+                xmppServerMock,
+                TEST_TIMEOUT,
+            );
             const olmSpy = spy(keyHandler._olmAdapter);
             const e2eeSpy = spy(keyHandler.e2eeCtx);
             const keyHandlerSpy = spy(keyHandler);
@@ -246,7 +251,7 @@ describe("Test E2E:", () => {
             verifySasValues(xmppServerMock);
         },
         MAX_TEST_TIME,
-    ); 
+    );
 
     it(
         "participants should sucessfully join an ongoing e2e meeting",
@@ -268,7 +273,11 @@ describe("Test E2E:", () => {
             verifyParticipantNumber(xmppServerMock, initialParticipantCount);
             verifySasValues(xmppServerMock);
             for (let i = 0; i < joinedParticipantsNumber; i++) {
-                const { id, keyHandler } = await createInitializedManagedKeyHandler(xmppServerMock, TEST_TIMEOUT);
+                const { id, keyHandler } =
+                    await createInitializedManagedKeyHandler(
+                        xmppServerMock,
+                        TEST_TIMEOUT,
+                    );
                 const olmSpy = spy(keyHandler._olmAdapter);
                 const e2eeSpy = spy(keyHandler.e2eeCtx);
                 const keyHandlerSpy = spy(keyHandler);
@@ -323,7 +332,7 @@ describe("Test E2E:", () => {
             verifySasValues(xmppServerMock);
         },
         MAX_TEST_TIME,
-    ); 
+    );
 
     it(
         "participants should sucessfully leave an ongoing e2e meeting",
@@ -371,7 +380,7 @@ describe("Test E2E:", () => {
             verifySasValues(xmppServerMock);
         },
         MAX_TEST_TIME,
-    ); 
+    );
 
     it(
         "participants should sucessfully join and leave an ongoing e2e meeting",
@@ -398,7 +407,11 @@ describe("Test E2E:", () => {
             verifySasValues(xmppServerMock);
 
             for (let i = 0; i < joinedParticipantsNumber; i++) {
-                const { id, keyHandler } = await createInitializedManagedKeyHandler(xmppServerMock, TEST_TIMEOUT);
+                const { id, keyHandler } =
+                    await createInitializedManagedKeyHandler(
+                        xmppServerMock,
+                        TEST_TIMEOUT,
+                    );
                 const olmSpy = spy(keyHandler._olmAdapter);
                 const e2eeSpy = spy(keyHandler.e2eeCtx);
                 const keyHandlerSpy = spy(keyHandler);
@@ -493,7 +506,11 @@ describe("Test E2E:", () => {
             );
 
             for (let i = 0; i < joinedParticipantsNumber; i++) {
-                const { id, keyHandler } = await createInitializedManagedKeyHandler(xmppServerMock, TEST_TIMEOUT);
+                const { id, keyHandler } =
+                    await createInitializedManagedKeyHandler(
+                        xmppServerMock,
+                        TEST_TIMEOUT,
+                    );
                 const olmSpy = spy(keyHandler._olmAdapter);
                 const e2eeSpy = spy(keyHandler.e2eeCtx);
                 const keyHandlerSpy = spy(keyHandler);
@@ -580,9 +597,13 @@ describe("Test E2E:", () => {
         async () => {
             const joinedParticipantsNumber = 4;
             const leftParticipantsNumber = 2;
-            expect(leftParticipantsNumber).toBeLessThanOrEqual(joinedParticipantsNumber);
+            expect(leftParticipantsNumber).toBeLessThanOrEqual(
+                joinedParticipantsNumber,
+            );
             expect(joinedParticipantsNumber).toBeGreaterThan(0);
-            expect(joinedParticipantsNumber + leftParticipantsNumber).toBeLessThan(10);
+            expect(
+                joinedParticipantsNumber + leftParticipantsNumber,
+            ).toBeLessThan(10);
 
             const { xmppServerMock, userData } = await createGroupMeeting(1);
 
@@ -590,7 +611,11 @@ describe("Test E2E:", () => {
             await delay(WAIT_FOR_CHANNELS);
 
             for (let i = 0; i < joinedParticipantsNumber; i++) {
-                const { id, keyHandler } = await createInitializedManagedKeyHandler(xmppServerMock, TEST_TIMEOUT);
+                const { id, keyHandler } =
+                    await createInitializedManagedKeyHandler(
+                        xmppServerMock,
+                        TEST_TIMEOUT,
+                    );
                 const olmSpy = spy(keyHandler._olmAdapter);
                 const e2eeSpy = spy(keyHandler.e2eeCtx);
                 const keyHandlerSpy = spy(keyHandler);
@@ -605,15 +630,11 @@ describe("Test E2E:", () => {
                 xmppServerMock.userJoined(keyHandler);
                 await delay(WAIT_FOR_CHANNELS);
             }
-            expect(userData.length).toBe(
-                1 + joinedParticipantsNumber,
-            );
+            expect(userData.length).toBe(1 + joinedParticipantsNumber);
 
             // meeting participants should ratchet their key as many times as number of user joined after them
             userData.forEach((user) => {
-                const x =
-                    joinedParticipantsNumber -
-                    user.index;
+                const x = joinedParticipantsNumber - user.index;
                 const times =
                     x > joinedParticipantsNumber ? joinedParticipantsNumber : x;
                 verify(user.olmSpy.ratchetMyKeys()).times(times);
@@ -627,7 +648,6 @@ describe("Test E2E:", () => {
                 await delay(WAIT_FOR_CHANNELS);
             }
 
-           
             // meeting participants should update their key as many times as number of left participants
             // (plus the initial update that set their keys)
             userData.forEach((user) => {
@@ -643,5 +663,5 @@ describe("Test E2E:", () => {
             verifySasValues(xmppServerMock);
         },
         MAX_TEST_TIME,
-    ); 
+    );
 });


### PR DESCRIPTION
It's an edge case...

Suppose participants A, B, and C are in an e2e call, and D, E, and F are joining at the same time.

Sometimes, participant D gets a notification that F joined before B gets the same notification (due to some XMPP internal delays and/or network issues and/or another Jitsi reason). 

If this happens, F does ratchet its key and has 6 participants in the call, while B doesn't ratchet its key and has 5 participants. It happens just for a few milliseconds, but if in this time window:
- B was establishing a session with D 
- The session was almost done (it had status WAITING_FOR_DONE)
- And key update info from B arrived AFTER D called the ratchet

Then **D will miss one ratchet** and wouldn't be able to decrypt B's video. 

If all those events align, then the workflow is the following:
- D does ratchet on B's key (as it should, because it received a signal that a new participant F joined and protocol had status WAITING_FOR_DONE)
- B sends and updated key info (as it should, because it ratcheted its key when E joined, and the session is not done yet).
- D received key info and updates B's key (as it should) <- **results in setting exactly the same key again**
- Then B finally gets a signal that a new participant F joined, **but the protocol is already done**, and it doesn't have to notify D.
- D can't decrypt B's video

**Fix:** 
Now, in updated key info, we include the current participant number. If it's less than expected, we do extra ratcheting.
<img width="602" alt="Screenshot 2025-05-07 at 17 23 57" src="https://github.com/user-attachments/assets/9994923e-c82f-49d3-919c-f8a2e0187dd1" />


**Note**
It happens because notifications of new participants arrive at different speeds for different users. I don't know why.