### PR TITLE
[_] Remove moderator

### DIFF
--- a/JitsiConference.ts
+++ b/JitsiConference.ts
@@ -522,7 +522,7 @@ export default class JitsiConference extends Listenable {
         this._iceRestarts = 0;
         this._unsubscribers = [];
 
-        this.eventEmitter.on(JitsiConferenceEvents.E2EE_CHAT_KEY_RECEIVED, key => {
+        this.eventEmitter.once(JitsiConferenceEvents.E2EE_CHAT_KEY_RECEIVED, key => {
             this.room.eventEmitter.emit(JitsiConferenceEvents.E2EE_CHAT_KEY_RECEIVED, key);
         });
     }

--- a/modules/e2ee-internxt/ManagedKeyHandler.ts
+++ b/modules/e2ee-internxt/ManagedKeyHandler.ts
@@ -418,7 +418,7 @@ export class ManagedKeyHandler extends Listenable {
                 (participant.hasFeature(FEATURE_E2EE)
                 || participant.getProperty('e2ee.enabled') === 'true')
                 && localParticipantId > participant.getId(),
-        );
+        ).sort((a, b) => a.getId().localeCompare(b.getId()));
 
         if (list.length === 0) return false;
         const firstParticipant = list[0].getId();

--- a/modules/e2ee-internxt/ManagedKeyHandler.ts
+++ b/modules/e2ee-internxt/ManagedKeyHandler.ts
@@ -423,7 +423,7 @@ export class ManagedKeyHandler extends Listenable {
         if (list.length === 0) return false;
         const firstParticipant = list[0].getId();
 
-        return firstParticipant == pId;
+        return firstParticipant === pId;
     }
 
     private async _onEndpointMessageReceived(participant: JitsiParticipant, payload) {

--- a/modules/e2ee-internxt/ManagedKeyHandler.ts
+++ b/modules/e2ee-internxt/ManagedKeyHandler.ts
@@ -795,7 +795,7 @@ export class ManagedKeyHandler extends Listenable {
             `Should send session-init to IDs: [ ${list.map(p => p.getId())}]`,
         );
 
-        if (!this.askedForChatKey && list.length == 0) {
+        if (!this.askedForChatKey && list.length === 0) {
             this.log('info', 'Generated chat keys');
             const chatKeyECC = genSymmetricKey();
             const chatKeyPQ = genSymmetricKey();

--- a/modules/e2ee-internxt/ManagedKeyHandler.ts
+++ b/modules/e2ee-internxt/ManagedKeyHandler.ts
@@ -410,12 +410,20 @@ export class ManagedKeyHandler extends Listenable {
         }
     }
 
-    private noOtherModerators(): boolean {
-        if (this.conference.isModerator()) return true;
-
+    private isThisParticipantFirst(pId: string): boolean {
+        const localParticipantId = this.myID;
         const participants = this.conference.getParticipants();
+        const list = participants.filter(
+            participant =>
+                (participant.hasFeature(FEATURE_E2EE)
+                || participant.getProperty('e2ee.enabled') === 'true')
+                && localParticipantId > participant.getId(),
+        );
 
-        return !participants.some(p => p.isModerator());
+        if (list.length === 0) return false;
+        const firstParticipant = list[0].getId();
+
+        return firstParticipant == pId;
     }
 
     private async _onEndpointMessageReceived(participant: JitsiParticipant, payload) {
@@ -516,7 +524,7 @@ export class ManagedKeyHandler extends Listenable {
                         pId,
                 );
 
-                if (!this.askedForChatKey && (participant.isModerator() || this.noOtherModerators())) {
+                if (!this.askedForChatKey && this.isThisParticipantFirst(pId)) {
                     this.log('info', `Requesting chat key from ${pId}.`);
                     this._sendMessage(
                         OLM_MESSAGE_TYPES.CHAT_KEY_REQUEST,

--- a/modules/xmpp/ChatRoom.ts
+++ b/modules/xmpp/ChatRoom.ts
@@ -342,7 +342,7 @@ export default class ChatRoom extends Listenable {
         this.transcriptionStatus = JitsiTranscriptionStatus.OFF;
         this.initialDiscoRoomInfoReceived = false;
 
-        this.eventEmitter.on(JitsiConferenceEvents.E2EE_CHAT_KEY_RECEIVED, this.setEncryptionKey.bind(this));
+        this.eventEmitter.once(JitsiConferenceEvents.E2EE_CHAT_KEY_RECEIVED, this.setEncryptionKey.bind(this));
 
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lib-jitsi-meet",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lib-jitsi-meet",
-      "version": "0.0.20",
+      "version": "0.0.21",
       "license": "Apache-2.0",
       "dependencies": {
         "@hexagon/base64": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lib-jitsi-meet",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "description": "JS library for accessing Jitsi server side deployments",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

Chat key is shared by the "oldest" user in the meeting instead of the moderator. 
This change allows for preventing errors when a moderator is assigned with a delay (due to a server being slow), or all users reconnect simultaneously.  

## How it was tested:

QA done with this PR: https://github.com/internxt/meet-web/pull/183

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.