### PR TITLE
[_] handle case when self is kicked out but not during login

### DIFF
--- a/JitsiConference.ts
+++ b/JitsiConference.ts
@@ -3470,6 +3470,14 @@ export default class JitsiConference extends Listenable {
         }
 
         if (isSelfPresence) {
+            if (!actorParticipant) {
+                // When meet-server kicks us we need to send the PARTICIPANT_KICKED event, but there is no
+                // JitsiParticipant object for ourselves so create a minimum fake one.
+                actorParticipant = {
+                    getDisplayName: () => 'Display Name',
+                    getId: () => kickedParticipantId,
+                };
+            }
             this.leave().finally(() => this._xmpp.disconnect());
             this.eventEmitter.emit(
                 JitsiConferenceEvents.KICKED, actorParticipant, reason, isReplaceParticipant);

--- a/modules/e2ee-internxt/ManagedKeyHandler.ts
+++ b/modules/e2ee-internxt/ManagedKeyHandler.ts
@@ -60,20 +60,20 @@ export class ManagedKeyHandler extends Listenable {
     e2eeCtx: E2EEContext;
     enabled: boolean;
     initialized: boolean;
-    initSessions: Promise<unknown[]>;
+    initSessions: Promise<unknown[]> | null;
     _olmAdapter: OlmAdapter;
     _conferenceJoined: boolean;
 
-    onUserJoined: EventListener;
-    onUserLeft: EventListener;
-    onEndpointMessageReceived: EventListener;
-    onConferenceJoined: EventListener;
-    onConferenceLeft: EventListener;
-    onMediaSessionStarted: EventListener;
-    onTrackAdded: EventListener;
-    onRemoteTrackAdded: EventListener;
-    onTrackMuteChanged: EventListener;
-    onSasUpdated: EventListener;
+    onUserJoined: ((id: string) => void) | undefined;
+    onUserLeft: ((id: string) => void) | undefined;
+    onEndpointMessageReceived: ((participant: JitsiParticipant, payload: any) => void) | undefined;
+    onConferenceJoined: (() => void) | undefined;
+    onConferenceLeft: (() => void) | undefined;
+    onMediaSessionStarted: ((session: JingleSessionPC) => void) | undefined;
+    onTrackAdded: ((track: JitsiTrack) => void) | undefined;
+    onRemoteTrackAdded: ((track: JitsiLocalTrack, tpc: TraceablePeerConnection) => void) | undefined;
+    onTrackMuteChanged: ((track: JitsiLocalTrack) => void) | undefined;
+    onSasUpdated: ((sasStr: string) => void) | undefined;
 
     /**
      * Build a new AutomaticKeyHandler instance, which will be used in a given conference.
@@ -83,7 +83,7 @@ export class ManagedKeyHandler extends Listenable {
         this.initialized = false;
         this.max_wait = REQ_TIMEOUT;
         this.conference = conference;
-        this.myID = conference.myUserId();
+        this.myID = conference.myUserId() || '';
         this.e2eeCtx = new E2EEContext();
         this._reqs = new Map();
         this.update = new Map();
@@ -94,6 +94,7 @@ export class ManagedKeyHandler extends Listenable {
         this.enabled = false;
         this._participantEventQueue = [];
         this._processingEvents = false;
+        this.initSessions = null;
 
         this.onUserJoined = this._onParticipantJoined.bind(this);
         this.onUserLeft = this._onParticipantLeft.bind(this);
@@ -134,7 +135,7 @@ export class ManagedKeyHandler extends Listenable {
             JitsiConferenceEvents.TRACK_ADDED,
             this.onTrackAdded,
         );
-        this.conference.rtc.on(
+        this.conference.rtc?.on(
             RTCEvents.REMOTE_TRACK_ADDED,
             this.onRemoteTrackAdded,
         );
@@ -922,7 +923,7 @@ export class ManagedKeyHandler extends Listenable {
             JitsiConferenceEvents.TRACK_ADDED,
             this.onTrackAdded,
         );
-        this.conference.rtc.off(
+        this.conference.rtc?.off(
             RTCEvents.REMOTE_TRACK_ADDED,
             this.onRemoteTrackAdded,
         );
@@ -932,16 +933,16 @@ export class ManagedKeyHandler extends Listenable {
         );
         this.e2eeCtx.off('sasUpdated', this.onSasUpdated);
 
-        this.onUserJoined = null;
-        this.onUserLeft = null;
-        this.onEndpointMessageReceived = null;
-        this.onConferenceJoined = null;
-        this.onConferenceLeft = null;
-        this.onMediaSessionStarted = null;
-        this.onTrackAdded = null;
-        this.onRemoteTrackAdded = null;
-        this.onTrackMuteChanged = null;
-        this.onSasUpdated = null;
+        this.onUserJoined = undefined;
+        this.onUserLeft = undefined;
+        this.onEndpointMessageReceived = undefined;
+        this.onConferenceJoined = undefined;
+        this.onConferenceLeft = undefined;
+        this.onMediaSessionStarted = undefined;
+        this.onTrackAdded = undefined;
+        this.onRemoteTrackAdded = undefined;
+        this.onTrackMuteChanged = undefined;
+        this.onSasUpdated = undefined;
 
         this.e2eeCtx.dispose();
         this._reqs.clear();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lib-meet",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lib-meet",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@hexagon/base64": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lib-meet",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "JS library for accessing Jitsi server side deployments",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

This PR adds a fix for kick-outs to work + small type check fix

## Motivation and Context

Jitsi has never handled a case where the server kicks out an already logged-in user due to duplicated login. They either kick out a duplicated user that is attempting to log in, or a moderator kicks out a meeting participant. So, our case was returning an undefined participant. Added a quick fix, similar to the one Jitsi has.

## How Has This Been Tested?

unit tests, QA in local

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.