### PR TITLE
[PB-6442] add requestAnimationFrame, remove unused code

### DIFF
--- a/JitsiConference.ts
+++ b/JitsiConference.ts
@@ -3425,6 +3425,8 @@ export default class JitsiConference extends Listenable {
             if (FeatureFlags.isSsrcRewritingSupported()) {
                 track.setSourceName(null);
                 track.setOwner(null);
+                console.warn('Decoder: disposing of an orphand track (tracksToBeRemoved)');
+                track.cleanDecoder();
             }
         });
 

--- a/JitsiConferenceEventManager.ts
+++ b/JitsiConferenceEventManager.ts
@@ -203,7 +203,12 @@ export default class JitsiConferenceEventManager {
                 track.setOwner(owner);
                 track.setSourceName(sourceName);
                 track._setVideoType(videoType);
-                owner && conference.eventEmitter.emit(JitsiConferenceEvents.TRACK_ADDED, track);
+                if (owner) {
+                    conference.eventEmitter.emit(JitsiConferenceEvents.TRACK_ADDED, track);
+                } else {
+                    console.warn('Decoder: disposing of an orphand track (chat room)');
+                    track.cleanDecoder();
+                }
             }
         });
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -42,6 +42,30 @@ module.exports = function(config) {
                 served: true,
                 watched: false
             },
+            {
+                included: false,
+                pattern: 'models/RTC/Decoder.onnx',
+                served: true,
+                watched: false
+            },
+            {
+                included: false,
+                pattern: 'node_modules/onnxruntime-web/dist/*.wasm',
+                served: true,
+                watched: false
+            },
+            {
+                included: false,
+                pattern: 'node_modules/onnxruntime-web/dist/*.mjs',
+                served: true,
+                watched: false
+            },
+            {
+                included: false,
+                pattern: 'node_modules/onnxruntime-web/dist/*.js',
+                served: true,
+                watched: false
+            },
             'node_modules/core-js/index.js',
             './modules/**/*.spec.ts',
             './service/**/*.spec.ts',
@@ -87,6 +111,11 @@ module.exports = function(config) {
             './**/*.spec.js': [ 'webpack', 'sourcemap' ],
             './**/*.spec.ts': [ 'webpack', 'sourcemap' ],
             'node_modules/core-js/**': [ 'webpack' ]
+        },
+
+        proxies: {
+            '/libs/dist/': '/base/node_modules/onnxruntime-web/dist/',
+            '/libs/models/': '/base/node_modules/lib-meet/models/'
         },
 
         // test results reporter to use

--- a/modules/RTC/JitsiRemoteTrack.ts
+++ b/modules/RTC/JitsiRemoteTrack.ts
@@ -85,11 +85,12 @@ export default class JitsiRemoteTrack extends JitsiTrack {
     private inputTensor: Nullable<any> = null;
     private dataOutput: Nullable<ImageData> = null;
     private inputBuffer: Nullable<Float32Array> = null;
+    private wasDisposed: boolean = false;
+    private trackID: string = 'no track ID yet';
 
     public ownerEndpointId: string;
     public isP2P: boolean;
     public rtcId: Nullable<string>;
-    public frame: Nullable<ImageBitmap> = null;
     public width: number = 0;
     public height: number = 0;
     public shouldDecode: boolean = false;
@@ -424,57 +425,88 @@ export default class JitsiRemoteTrack extends JitsiTrack {
      * @param container the HTML container which can be 'video' or 'audio'
      * element.
      */
-    increaseResolution(container: any) {
-        if (this._animationFrameId) cancelAnimationFrame(this._animationFrameId);
+    increaseResolution(container: HTMLElement) {
+        if (this._animationFrameId) {
+            logger.warn('Decoder: canceling animation frame for track:', this.trackID);
+            cancelAnimationFrame(this._animationFrameId);
+        }
         const canvasDecoded = document.createElement('canvas');
 
         this._decodedStream = canvasDecoded.captureStream();
+
+        let videoTrack = this.stream.getVideoTracks()[0];
+
+        this.trackID = videoTrack.id;
+
+        logger.info('Decoder: start increase resolution for track:', this.trackID, 'corresponding to', this.getParticipantId());
+        // Frame-grabber to catch frames from the incoming stream
+        let imageCapture = new ImageCapture(videoTrack);
+        // Setting up the aux canvas to paint the caught frames
         // Extracting track from canvas-sender
         const canvasEncoded = document.createElement('canvas');
         const ctxEncoded = canvasEncoded.getContext('2d', { willReadFrequently: true });
         const ctxDecoded = canvasDecoded.getContext('2d', { willReadFrequently: true });
 
         this.isProcessingFrame = false;
+        this.wasDisposed = false;
         const processFrame = async () => {
+            if (!this.getParticipantId()) {
+                logger.error('Decoder: Was called for an orphaned track! Cleaning up..');
 
+                if (this.decoderIsOn) RTCUtils.attachMediaStream(container, this.stream);
+                this.cleanDecoder();
+
+                return;
+
+            }
+            if (this.wasDisposed) {
+                logger.warn('Decoder: stopping because disposed was called for this track:', this.trackID);
+
+                return;
+            }
             if (this.isProcessingFrame) {
-                logger.warn('Decoder: skipping a frame because the previous one is still being processed');
+                logger.warn('Decoder: skipping a frame because the previous one is still being processed for track', this.trackID);
                 this._animationFrameId = requestAnimationFrame(processFrame);
 
                 return;
             }
 
-            const videoTrack = this.stream.getVideoTracks()[0];
-            // Frame-grabber to catch frames from the incoming stream
-            const imageCapture = new ImageCapture(videoTrack);
-            // Setting up the aux canvas to paint the caught frames
+            const currentVideoTrack = this.stream.getVideoTracks()[0];
+
+            if (videoTrack !== currentVideoTrack) {
+                console.log('Decoder: changing video track and image capture due to track change');
+
+                videoTrack = currentVideoTrack;
+                imageCapture = new ImageCapture(videoTrack);
+            }
 
             if (videoTrack.readyState === 'live') {
-                let outInference: Nullable<any>;
+                let outInference: Nullable<any> = null;
+                let frame: ImageBitmap | null = null;
 
                 try {
                     this.isProcessingFrame = true;
                     try {
-                        this.frame = await imageCapture.grabFrame();
+                        frame = await imageCapture.grabFrame();
                     } catch (err) {
-                        logger.warn('Decoder: could not catch the frame: ', err);
-                        throw new Error('Decoder: could not catch the frame');
+                        logger.warn('Decoder: could not catch the frame for track:', this.trackID, 'corresponding to', this.getParticipantId(), 'error:', err);
+                        throw new Error('Decoder: could not catch the frame for track:' + this.trackID);
                     }
                     // Getting the current size of the incoming stream
-                    const nwidth = this.frame.width;
-                    const nheight = this.frame.height;
+                    const nwidth = frame.width;
+                    const nheight = frame.height;
 
                     if (!nwidth || !nheight) {
-                        logger.warn('Decoder: invalid track dimensions, skipping frame:', 'width:', nwidth, 'height:', nheight);
-                        throw new Error('Decoder: invalid track dimensions, skipping frame');
+                        logger.warn('Decoder: invalid track dimensions, skipping frame for track', this.trackID, 'width:', nwidth, 'height:', nheight);
+                        throw new Error('Decoder: invalid track dimensions, skipping frame for track:' + this.trackID);
                     }
 
                     if (nheight < 240 && !this.decoderIsOn) {
-                        logger.info('Decoder: Activating decoder for track:', videoTrack, 'new resolution: ', nwidth, 'x', nheight);
+                        logger.info('Decoder: Activating decoder for track:', this.trackID, 'frame resolution: ', nwidth, 'x', nheight);
                         this.shouldDecode = true;
                     }
                     if (nheight >= 240 && this.decoderIsOn) {
-                        logger.info('Decoder: Deactivating decoder for track:', videoTrack, 'new resolution: ', nwidth, 'x', nheight);
+                        logger.info('Decoder: Deactivating decoder for track:', this.trackID, 'frame resolution: ', nwidth, 'x', nheight);
                         this.shouldDecode = false;
                     }
                     if (this.shouldDecode) {
@@ -495,45 +527,45 @@ export default class JitsiRemoteTrack extends JitsiTrack {
                                 this.width = nwidth;
                                 this.height = nheight;
                             } catch (err) {
-                                logger.error('Decoder: Could not set new resolution', err);
-                                throw new Error('Decoder: Could not set new resolution');
+                                logger.error('Decoder: Could not set new resolution for track:', this.trackID, 'error:', err);
+                                throw new Error('Decoder: Could not set new resolution for track' + this.trackID);
                             }
                         }
-                        ctxEncoded.drawImage(this.frame, 0, 0, this.width, this.height);
+                        ctxEncoded.drawImage(frame, 0, 0, this.width, this.height);
                         const imageEncode = ctxEncoded.getImageData(0, 0, this.width, this.height);
 
                         try {
                             this.inputBuffer.set(imageEncode.data);
                         } catch (err) {
-                            logger.error('Decoder: float32 buffer could not be set: ', err);
+                            logger.error('Decoder: float32 buffer could not be set for track:', this.trackID, 'error:', err);
                             throw new Error('Decoder: float32 buffer could not be set');
                         }
 
                         try {
                             outInference = await decodingSession.run({ input: this.inputTensor });
                         } catch (err) {
-                            logger.error('Decoder: could not run onnx session: ', err);
+                            logger.error('Decoder: could not run onnx session for track:', this.trackID, 'error:', err);
                             throw new Error('Decoder: could not run onnx session');
                         }
                         try {
                             this.dataOutput.data.set(outInference.output.data);
                             ctxDecoded.putImageData(this.dataOutput, 0, 0);
                         } catch (err) {
-                            logger.error('Decoder: could not set output frame: ', err);
+                            logger.error('Decoder: could not set output frame for track:', this.trackID, 'error:', err);
                             throw new Error('Decoder: could not set output frame');
                         }
 
                         if (!this.decoderIsOn) {
                             this.decoderIsOn = true;
-                            logger.info('Decoder: ON');
+                            logger.info('Decoder: ON for track:', this.trackID);
                             RTCUtils.attachMediaStream(container, this._decodedStream);
                         }
                     }
                 } catch (error) {
                     this.shouldDecode = false;
                 } finally {
-                    this.frame?.close();
-                    this.frame = null;
+                    frame?.close();
+                    frame = null;
                     outInference?.output.dispose();
                     outInference = null;
                     this.isProcessingFrame = false;
@@ -541,11 +573,17 @@ export default class JitsiRemoteTrack extends JitsiTrack {
 
                 if (this.decoderIsOn && !this.shouldDecode) {
                     this.decoderIsOn = false;
-                    logger.info('Decoder: OFF');
+                    logger.info('Decoder: OFF for track', this.trackID);
                     RTCUtils.attachMediaStream(container, this.stream);
                 }
             }
-            this._animationFrameId = requestAnimationFrame(processFrame);
+            if (this.wasDisposed) {
+                logger.info('Decoder: Finished processing frame and track was already disposed, clean up just in case');
+                if (this.decoderIsOn) RTCUtils.attachMediaStream(container, this.stream);
+                this.cleanDecoder();
+
+                return;
+            } else this._animationFrameId = requestAnimationFrame(processFrame);
 
         };
 
@@ -567,10 +605,9 @@ export default class JitsiRemoteTrack extends JitsiTrack {
 
         if (this.stream) {
             this._onTrackAttach(container);
+            result = RTCUtils.attachMediaStream(container, this.stream);
             if (this.type === MediaType.VIDEO && this.videoType === VideoType.CAMERA && decode && !browser.isSafari()) {
                 this.increaseResolution(container);
-            } else {
-                result = RTCUtils.attachMediaStream(container, this.stream);
             }
         }
         this.containers.push(container);
@@ -631,20 +668,11 @@ export default class JitsiRemoteTrack extends JitsiTrack {
         return this._enteredForwardedSourcesTimestamp;
     }
 
-    /**
-     * Removes attached event listeners and dispose TrackStreamingStatus .
-     *
-     * @returns {Promise}
-     */
-    override async dispose(): Promise<void> {
-        logger.info('Decoder: cleaning');
+    cleanDecoder() {
+        logger.info('Decoder: cleaning is called for track:', this.trackID);
         if (this._animationFrameId !== null) {
             cancelAnimationFrame(this._animationFrameId);
             this._animationFrameId = null;
-        }
-        if (this.frame) {
-            this.frame.close();
-            this.frame = null;
         }
         if (this.inputTensor) {
             this.inputTensor.dispose();
@@ -660,7 +688,22 @@ export default class JitsiRemoteTrack extends JitsiTrack {
         this.width = 0;
         this.height = 0;
         this.dataOutput = null;
-        this.inputBuffer = null;
+        this.wasDisposed = true;
+
+    }
+
+    /**
+     * Removes attached event listeners and dispose TrackStreamingStatus .
+     *
+     * @returns {Promise}
+     */
+    override async dispose(): Promise<void> {
+
+        if (this.type === MediaType.VIDEO && this.videoType === VideoType.CAMERA && !browser.isSafari() && !this.wasDisposed) {
+            console.log('Decoder: dispose called');
+            this.cleanDecoder();
+        }
+
         if (this.disposed) {
             return;
         }

--- a/modules/RTC/JitsiRemoteTrack.ts
+++ b/modules/RTC/JitsiRemoteTrack.ts
@@ -82,17 +82,17 @@ export default class JitsiRemoteTrack extends JitsiTrack {
     private _hasBeenMuted: boolean;
     private _ssrc: number;
     private _animationFrameId: Nullable<number> = null;
+    private inputTensor: Nullable<any> = null;
+    private dataOutput: Nullable<ImageData> = null;
+    private inputBuffer: Nullable<Float32Array> = null;
 
     public ownerEndpointId: string;
     public isP2P: boolean;
     public rtcId: Nullable<string>;
-    public inputTensor: Nullable<any> = null;
-    public dataOutput: Nullable<ImageData> = null;
-    public inputBuffer: Nullable<Float32Array> = null;
     public frame: Nullable<ImageBitmap> = null;
     public width: number = 0;
     public height: number = 0;
-    public activedecoder: boolean = false;
+    public shouldDecode: boolean = false;
     public decoderIsOn: boolean = false;
     public isProcessingFrame: boolean = false;
 
@@ -449,7 +449,7 @@ export default class JitsiRemoteTrack extends JitsiTrack {
             const imageCapture = new ImageCapture(videoTrack);
             // Setting up the aux canvas to paint the caught frames
 
-            if (videoTrack.readyState == 'live') {
+            if (videoTrack.readyState === 'live') {
                 let outInference: Nullable<any>;
 
                 try {
@@ -471,13 +471,13 @@ export default class JitsiRemoteTrack extends JitsiTrack {
 
                     if (nheight < 240 && !this.decoderIsOn) {
                         logger.info('Decoder: Activating decoder for track:', videoTrack, 'new resolution: ', nwidth, 'x', nheight);
-                        this.activedecoder = true;
+                        this.shouldDecode = true;
                     }
                     if (nheight >= 240 && this.decoderIsOn) {
                         logger.info('Decoder: Deactivating decoder for track:', videoTrack, 'new resolution: ', nwidth, 'x', nheight);
-                        this.activedecoder = false;
+                        this.shouldDecode = false;
                     }
-                    if (this.activedecoder) {
+                    if (this.shouldDecode) {
                         // check wether the canvas must be changed
                         if (this.width != nwidth || this.height != nheight || !this.dataOutput || !this.inputBuffer) {
                             try {
@@ -530,7 +530,7 @@ export default class JitsiRemoteTrack extends JitsiTrack {
                         }
                     }
                 } catch (error) {
-                    this.activedecoder = false;
+                    this.shouldDecode = false;
                 } finally {
                     this.frame?.close();
                     this.frame = null;
@@ -539,7 +539,7 @@ export default class JitsiRemoteTrack extends JitsiTrack {
                     this.isProcessingFrame = false;
                 }
 
-                if (this.decoderIsOn && !this.activedecoder) {
+                if (this.decoderIsOn && !this.shouldDecode) {
                     this.decoderIsOn = false;
                     logger.info('Decoder: OFF');
                     RTCUtils.attachMediaStream(container, this.stream);
@@ -654,7 +654,7 @@ export default class JitsiRemoteTrack extends JitsiTrack {
             this._decodedStream.getTracks().forEach(t => t.stop());
             this._decodedStream = null;
         }
-        this.activedecoder = false;
+        this.shouldDecode = false;
         this.isProcessingFrame = false;
         this.decoderIsOn = false;
         this.width = 0;

--- a/modules/RTC/JitsiRemoteTrack.ts
+++ b/modules/RTC/JitsiRemoteTrack.ts
@@ -94,8 +94,7 @@ export default class JitsiRemoteTrack extends JitsiTrack {
     public height: number;
     public outInference: Nullable<any>;
     public activedecoder: boolean;
-    public attachoff: boolean;
-    public attachon: boolean;
+    public decoderIsOn: boolean;
     public imageEncode: Nullable<ImageData>;
     public inputData: Nullable<any>;
     public inputBuffer: Nullable<any>;
@@ -193,8 +192,7 @@ export default class JitsiRemoteTrack extends JitsiTrack {
         this.inputBuffer = null;
         this.outInference = null;
         this.activedecoder = false;
-        this.attachoff = false;
-        this.attachon = false;
+        this.decoderIsOn = false;
         this.imageEncode = null;
         this.inputData = null;
     }
@@ -463,7 +461,7 @@ export default class JitsiRemoteTrack extends JitsiTrack {
                     }
                     this.frame = await imageCapture.grabFrame();
                 } catch (err) {
-                    logger.info('Decoder: could not catch the frame: ', err);
+                    logger.error('Decoder: could not catch the frame: ', err);
                     this._animationFrameId = requestAnimationFrame(processFrame);
 
                     return;
@@ -479,16 +477,16 @@ export default class JitsiRemoteTrack extends JitsiTrack {
                     return;
                 }
 
-                if (nheight < 240 && !this.attachon) {
+                if (nheight < 240 && !this.decoderIsOn) {
                     logger.info('Decoder: Activating decoder for track:', videoTrack, 'new resolution: ', nwidth, 'x', nheight);
                     this.activedecoder = true;
                 }
-                if (nheight >= 240 && !this.attachoff) {
+                if (nheight >= 240 && this.decoderIsOn) {
                     logger.info('Decoder: Deactivating decoder for track:', videoTrack, 'new resolution: ', nwidth, 'x', nheight);
                     this.activedecoder = false;
                 }
-                // check wether the canvas must be changed
                 if (this.activedecoder) {
+                    // check wether the canvas must be changed
                     if (this.width != nwidth || this.height != nheight) {
                         try {
                             if (this.inputTensor) {
@@ -506,8 +504,9 @@ export default class JitsiRemoteTrack extends JitsiTrack {
                             this.width = nwidth;
                             this.height = nheight;
                         } catch (err) {
-                            logger.info('Decoder: Could not set new resolution', err);
+                            logger.error('Decoder: Could not set new resolution', err);
                             this._animationFrameId = requestAnimationFrame(processFrame);
+                            this.activedecoder = false;
 
                             return;
                         }
@@ -521,8 +520,9 @@ export default class JitsiRemoteTrack extends JitsiTrack {
                     try {
                         this.inputBuffer.set(this.inputData);
                     } catch (err) {
-                        logger.info('Decoder: float32 buffer could not be set: ', err);
+                        logger.error('Decoder: float32 buffer could not be set: ', err);
                         this._animationFrameId = requestAnimationFrame(processFrame);
+                        this.activedecoder = false;
 
                         return;
                     }
@@ -530,18 +530,20 @@ export default class JitsiRemoteTrack extends JitsiTrack {
                     try {
                         this.outInference = await decodingSession.run(this.input);
                     } catch (err) {
-                        logger.info('Decoder: could not run onnx session: ', err);
+                        logger.error('Decoder: could not run onnx session: ', err);
                         this._animationFrameId = requestAnimationFrame(processFrame);
+                        this.activedecoder = false;
 
                         return;
                     }
 
                     try {
-                        this.dataOutput.data.set(this.outInference.output.data);
-                        ctxDecoded.putImageData(this.dataOutput, 0, 0);
+                        this.dataOutput?.data.set(this.outInference.output.data);
+                        ctxDecoded?.putImageData(this.dataOutput, 0, 0);
                     } catch (err) {
-                        logger.info('Decoder: output frame could not be set: ', err);
+                        logger.error('Decoder: output frame could not be set: ', err);
                         this._animationFrameId = requestAnimationFrame(processFrame);
+                        this.activedecoder = false;
 
                         return;
                     }
@@ -550,24 +552,17 @@ export default class JitsiRemoteTrack extends JitsiTrack {
                     this.inputData = null;
                     this.outInference.output.dispose();
                     this.outInference = null;
-                }
-                if (!this.attachoff && !this.activedecoder) {
-                    if (container.srcObject) {
-                        container.srcObject = null;
+
+                    if (!this.decoderIsOn) {
+                        this.decoderIsOn = true;
+                        logger.info('Decoder: ON');
+                        RTCUtils.attachMediaStream(container, this._decodedStream);
                     }
-                    this.attachoff = true;
-                    this.attachon = false;
+                }
+                if (this.decoderIsOn && !this.activedecoder) {
+                    this.decoderIsOn = false;
                     logger.info('Decoder: OFF');
                     RTCUtils.attachMediaStream(container, this.stream);
-                }
-                if (!this.attachon && this.activedecoder) {
-                    if (container.srcObject) {
-                        container.srcObject = null;
-                    }
-                    this.attachon = true;
-                    this.attachoff = false;
-                    logger.info('Decoder: ON');
-                    RTCUtils.attachMediaStream(container, this._decodedStream);
                 }
             }
             this._animationFrameId = requestAnimationFrame(processFrame);
@@ -683,8 +678,7 @@ export default class JitsiRemoteTrack extends JitsiTrack {
             this._decodedStream = null;
         }
         this.activedecoder = false;
-        this.attachon = false;
-        this.attachoff = false;
+        this.decoderIsOn = false;
         this.width = 0;
         this.height = 0;
         this.dataOutput = null;

--- a/modules/RTC/JitsiRemoteTrack.ts
+++ b/modules/RTC/JitsiRemoteTrack.ts
@@ -30,9 +30,9 @@ export let decodingSession = null;
 /**
  * Loads the decoder model
  */
-async function loadDecoder() {
+export async function loadDecoder(modelPath = '/libs/models/Decoder.onnx') {
     try {
-        decodingSession = await ort.InferenceSession.create('/libs/models/Decoder.onnx',
+        decodingSession = await ort.InferenceSession.create(modelPath,
             {
                 enableCpuMemArena: false,
                 executionProviders: [ 'wasm' ],
@@ -75,7 +75,7 @@ export default class JitsiRemoteTrack extends JitsiTrack {
      * will become interrupted.
      */
     private _containerHandlers: { [key: string]: (event: Event) => void; };
-    private _decodedStream: Nullable<MediaStream>;
+    private _decodedStream: Nullable<MediaStream> = null;
     private _enteredForwardedSourcesTimestamp: Nullable<number>;
     private _rtc: RTC;
     private _muted: boolean;
@@ -86,18 +86,15 @@ export default class JitsiRemoteTrack extends JitsiTrack {
     public ownerEndpointId: string;
     public isP2P: boolean;
     public rtcId: Nullable<string>;
-    public inputTensor: Nullable<any>;
-    public dataOutput: Nullable<ImageData>;
-    public input: Nullable<any>;
-    public frame: Nullable<ImageBitmap>;
-    public width: number;
-    public height: number;
-    public outInference: Nullable<any>;
-    public activedecoder: boolean;
-    public decoderIsOn: boolean;
-    public imageEncode: Nullable<ImageData>;
-    public inputData: Nullable<any>;
-    public inputBuffer: Nullable<any>;
+    public inputTensor: Nullable<any> = null;
+    public dataOutput: Nullable<ImageData> = null;
+    public inputBuffer: Nullable<Float32Array> = null;
+    public frame: Nullable<ImageBitmap> = null;
+    public width: number = 0;
+    public height: number = 0;
+    public activedecoder: boolean = false;
+    public decoderIsOn: boolean = false;
+    public isProcessingFrame: boolean = false;
 
     /**
      * Creates new JitsiRemoteTrack instance.
@@ -178,23 +175,6 @@ export default class JitsiRemoteTrack extends JitsiTrack {
             this._containerHandlers[event] = this._containerEventHandler.bind(this, event);
         });
 
-        // Decoding streams the incoming videtrack
-        this._decodedStream = null;
-        // Steam objects
-        this.inputTensor = null;
-        this.dataOutput = null;
-        this.input = {
-            input: null
-        };
-        this.frame = null;
-        this.width = 0;
-        this.height = 0;
-        this.inputBuffer = null;
-        this.outInference = null;
-        this.activedecoder = false;
-        this.decoderIsOn = false;
-        this.imageEncode = null;
-        this.inputData = null;
     }
 
     /* eslint-enable max-params */
@@ -435,6 +415,10 @@ export default class JitsiRemoteTrack extends JitsiTrack {
         container.addEventListener('canplay', this._playCallback.bind(this));
     }
 
+    isDecoderOn(): boolean {
+        return this.decoderIsOn;
+    }
+
     /**
      *  Performs the decoding routine to increase resolution
      * @param container the HTML container which can be 'video' or 'audio'
@@ -446,119 +430,116 @@ export default class JitsiRemoteTrack extends JitsiTrack {
 
         this._decodedStream = canvasDecoded.captureStream();
         // Extracting track from canvas-sender
-        const videoTrack = this.stream.getVideoTracks()[0];
-        // Frame-grabber to catch frames from the incoming stream
-        const imageCapture = new ImageCapture(videoTrack);
-        // Setting up the aux canvas to paint the caught frames
         const canvasEncoded = document.createElement('canvas');
         const ctxEncoded = canvasEncoded.getContext('2d', { willReadFrequently: true });
         const ctxDecoded = canvasDecoded.getContext('2d', { willReadFrequently: true });
+
+        this.isProcessingFrame = false;
         const processFrame = async () => {
+
+            if (this.isProcessingFrame) {
+                logger.warn('Decoder: skipping a frame because the previous one is still being processed');
+                this._animationFrameId = requestAnimationFrame(processFrame);
+
+                return;
+            }
+
+            const videoTrack = this.stream.getVideoTracks()[0];
+            // Frame-grabber to catch frames from the incoming stream
+            const imageCapture = new ImageCapture(videoTrack);
+            // Setting up the aux canvas to paint the caught frames
+
             if (videoTrack.readyState == 'live') {
+                let outInference: Nullable<any>;
+
                 try {
-                    if (this.frame) {
-                        this.frame.close();
+                    this.isProcessingFrame = true;
+                    try {
+                        this.frame = await imageCapture.grabFrame();
+                    } catch (err) {
+                        logger.warn('Decoder: could not catch the frame: ', err);
+                        throw new Error('Decoder: could not catch the frame');
                     }
-                    this.frame = await imageCapture.grabFrame();
-                } catch (err) {
-                    logger.error('Decoder: could not catch the frame: ', err);
-                    this._animationFrameId = requestAnimationFrame(processFrame);
+                    // Getting the current size of the incoming stream
+                    const nwidth = this.frame.width;
+                    const nheight = this.frame.height;
 
-                    return;
-                }
-                // Getting the current size of the incoming stream
-                const nwidth = this.frame.width;
-                const nheight = this.frame.height;
+                    if (!nwidth || !nheight) {
+                        logger.warn('Decoder: invalid track dimensions, skipping frame:', 'width:', nwidth, 'height:', nheight);
+                        throw new Error('Decoder: invalid track dimensions, skipping frame');
+                    }
 
-                if (!nwidth || !nheight) {
-                    logger.warn('Decoder: invalid track dimensions, skipping frame:', 'width:', nwidth, 'height:', nheight);
-                    this._animationFrameId = requestAnimationFrame(processFrame);
-
-                    return;
-                }
-
-                if (nheight < 240 && !this.decoderIsOn) {
-                    logger.info('Decoder: Activating decoder for track:', videoTrack, 'new resolution: ', nwidth, 'x', nheight);
-                    this.activedecoder = true;
-                }
-                if (nheight >= 240 && this.decoderIsOn) {
-                    logger.info('Decoder: Deactivating decoder for track:', videoTrack, 'new resolution: ', nwidth, 'x', nheight);
-                    this.activedecoder = false;
-                }
-                if (this.activedecoder) {
-                    // check wether the canvas must be changed
-                    if (this.width != nwidth || this.height != nheight) {
-                        try {
-                            if (this.inputTensor) {
-                                this.inputTensor.dispose();
-                                this.inputTensor = null;
+                    if (nheight < 240 && !this.decoderIsOn) {
+                        logger.info('Decoder: Activating decoder for track:', videoTrack, 'new resolution: ', nwidth, 'x', nheight);
+                        this.activedecoder = true;
+                    }
+                    if (nheight >= 240 && this.decoderIsOn) {
+                        logger.info('Decoder: Deactivating decoder for track:', videoTrack, 'new resolution: ', nwidth, 'x', nheight);
+                        this.activedecoder = false;
+                    }
+                    if (this.activedecoder) {
+                        // check wether the canvas must be changed
+                        if (this.width != nwidth || this.height != nheight || !this.dataOutput || !this.inputBuffer) {
+                            try {
+                                if (this.inputTensor) {
+                                    this.inputTensor.dispose();
+                                    this.inputTensor = null;
+                                }
+                                canvasEncoded.width = nwidth;
+                                canvasEncoded.height = nheight;
+                                canvasDecoded.width = nwidth * 2;
+                                canvasDecoded.height = nheight * 2;
+                                this.inputBuffer = new Float32Array(nwidth * nheight * 4);
+                                this.inputTensor = new ort.Tensor('float32', this.inputBuffer, [ 1, nheight, nwidth, 4 ]);
+                                this.dataOutput = new ImageData(2 * nwidth, 2 * nheight);
+                                this.width = nwidth;
+                                this.height = nheight;
+                            } catch (err) {
+                                logger.error('Decoder: Could not set new resolution', err);
+                                throw new Error('Decoder: Could not set new resolution');
                             }
-                            canvasEncoded.width = nwidth;
-                            canvasEncoded.height = nheight;
-                            canvasDecoded.width = nwidth * 2;
-                            canvasDecoded.height = nheight * 2;
-                            this.inputBuffer = new Float32Array(nwidth * nheight * 4);
-                            this.inputTensor = new ort.Tensor('float32', this.inputBuffer, [ 1, nheight, nwidth, 4 ]);
-                            this.input.input = this.inputTensor;
-                            this.dataOutput = new ImageData(2 * nwidth, 2 * nheight);
-                            this.width = nwidth;
-                            this.height = nheight;
-                        } catch (err) {
-                            logger.error('Decoder: Could not set new resolution', err);
-                            this._animationFrameId = requestAnimationFrame(processFrame);
-                            this.activedecoder = false;
+                        }
+                        ctxEncoded.drawImage(this.frame, 0, 0, this.width, this.height);
+                        const imageEncode = ctxEncoded.getImageData(0, 0, this.width, this.height);
 
-                            return;
+                        try {
+                            this.inputBuffer.set(imageEncode.data);
+                        } catch (err) {
+                            logger.error('Decoder: float32 buffer could not be set: ', err);
+                            throw new Error('Decoder: float32 buffer could not be set');
+                        }
+
+                        try {
+                            outInference = await decodingSession.run({ input: this.inputTensor });
+                        } catch (err) {
+                            logger.error('Decoder: could not run onnx session: ', err);
+                            throw new Error('Decoder: could not run onnx session');
+                        }
+                        try {
+                            this.dataOutput.data.set(outInference.output.data);
+                            ctxDecoded.putImageData(this.dataOutput, 0, 0);
+                        } catch (err) {
+                            logger.error('Decoder: could not set output frame: ', err);
+                            throw new Error('Decoder: could not set output frame');
+                        }
+
+                        if (!this.decoderIsOn) {
+                            this.decoderIsOn = true;
+                            logger.info('Decoder: ON');
+                            RTCUtils.attachMediaStream(container, this._decodedStream);
                         }
                     }
-
-                    ctxEncoded.drawImage(this.frame, 0, 0, this.width, this.height);
-                    this.frame.close();
-                    this.imageEncode = ctxEncoded.getImageData(0, 0, this.width, this.height);
-                    this.inputData = this.imageEncode.data;
-
-                    try {
-                        this.inputBuffer.set(this.inputData);
-                    } catch (err) {
-                        logger.error('Decoder: float32 buffer could not be set: ', err);
-                        this._animationFrameId = requestAnimationFrame(processFrame);
-                        this.activedecoder = false;
-
-                        return;
-                    }
-
-                    try {
-                        this.outInference = await decodingSession.run(this.input);
-                    } catch (err) {
-                        logger.error('Decoder: could not run onnx session: ', err);
-                        this._animationFrameId = requestAnimationFrame(processFrame);
-                        this.activedecoder = false;
-
-                        return;
-                    }
-
-                    try {
-                        this.dataOutput?.data.set(this.outInference.output.data);
-                        ctxDecoded?.putImageData(this.dataOutput, 0, 0);
-                    } catch (err) {
-                        logger.error('Decoder: output frame could not be set: ', err);
-                        this._animationFrameId = requestAnimationFrame(processFrame);
-                        this.activedecoder = false;
-
-                        return;
-                    }
-                    // Cleaning canvas, arrays and tensors
-                    this.imageEncode = null;
-                    this.inputData = null;
-                    this.outInference.output.dispose();
-                    this.outInference = null;
-
-                    if (!this.decoderIsOn) {
-                        this.decoderIsOn = true;
-                        logger.info('Decoder: ON');
-                        RTCUtils.attachMediaStream(container, this._decodedStream);
-                    }
+                } catch (error) {
+                    this.activedecoder = false;
+                    this._animationFrameId = requestAnimationFrame(processFrame);
+                } finally {
+                    this.frame?.close();
+                    this.frame = null;
+                    outInference?.output.dispose();
+                    outInference = null;
+                    this.isProcessingFrame = false;
                 }
+
                 if (this.decoderIsOn && !this.activedecoder) {
                     this.decoderIsOn = false;
                     logger.info('Decoder: OFF');
@@ -566,6 +547,7 @@ export default class JitsiRemoteTrack extends JitsiTrack {
                 }
             }
             this._animationFrameId = requestAnimationFrame(processFrame);
+
         };
 
         processFrame();
@@ -669,20 +651,16 @@ export default class JitsiRemoteTrack extends JitsiTrack {
             this.inputTensor.dispose();
             this.inputTensor = null;
         }
-        if (this.outInference) {
-            this.outInference.output.dispose();
-            this.outInference = null;
-        }
         if (this._decodedStream) {
             this._decodedStream.getTracks().forEach(t => t.stop());
             this._decodedStream = null;
         }
         this.activedecoder = false;
+        this.isProcessingFrame = false;
         this.decoderIsOn = false;
         this.width = 0;
         this.height = 0;
         this.dataOutput = null;
-        this.input = null;
         this.inputBuffer = null;
         if (this.disposed) {
             return;

--- a/modules/RTC/JitsiRemoteTrack.ts
+++ b/modules/RTC/JitsiRemoteTrack.ts
@@ -531,7 +531,6 @@ export default class JitsiRemoteTrack extends JitsiTrack {
                     }
                 } catch (error) {
                     this.activedecoder = false;
-                    this._animationFrameId = requestAnimationFrame(processFrame);
                 } finally {
                     this.frame?.close();
                     this.frame = null;

--- a/modules/RTC/JitsiRemoteTrack.ts
+++ b/modules/RTC/JitsiRemoteTrack.ts
@@ -75,14 +75,13 @@ export default class JitsiRemoteTrack extends JitsiTrack {
      * will become interrupted.
      */
     private _containerHandlers: { [key: string]: (event: Event) => void; };
-    private _decodedStream;
-    private _decodedTrack;
+    private _decodedStream: Nullable<MediaStream>;
     private _enteredForwardedSourcesTimestamp: Nullable<number>;
     private _rtc: RTC;
     private _muted: boolean;
     private _hasBeenMuted: boolean;
     private _ssrc: number;
-    private _animationFrameId: number;
+    private _animationFrameId: Nullable<number> = null;
 
     public ownerEndpointId: string;
     public isP2P: boolean;
@@ -182,7 +181,6 @@ export default class JitsiRemoteTrack extends JitsiTrack {
 
         // Decoding streams the incoming videtrack
         this._decodedStream = null;
-        this._decodedTrack = null;
         // Steam objects
         this.inputTensor = null;
         this.dataOutput = null;
@@ -440,22 +438,6 @@ export default class JitsiRemoteTrack extends JitsiTrack {
     }
 
     /**
-     * Returns decoded stream from camera stream
-     * @returns MediaStream object
-     */
-    getDecodedStream() {
-        return this._decodedStream;
-    }
-
-    /**
-     * Returns decoded stream from camera stream
-     * @returns Track object
-     */
-    getDecodedTrack() {
-        return this._decodedTrack;
-    }
-
-    /**
      *  Performs the decoding routine to increase resolution
      * @param container the HTML container which can be 'video' or 'audio'
      * element.
@@ -466,7 +448,6 @@ export default class JitsiRemoteTrack extends JitsiTrack {
 
         this._decodedStream = canvasDecoded.captureStream();
         // Extracting track from canvas-sender
-        this._decodedTrack = this._decodedStream.getVideoTracks()[0];
         const videoTrack = this.stream.getVideoTracks()[0];
         // Frame-grabber to catch frames from the incoming stream
         const imageCapture = new ImageCapture(videoTrack);
@@ -474,8 +455,6 @@ export default class JitsiRemoteTrack extends JitsiTrack {
         const canvasEncoded = document.createElement('canvas');
         const ctxEncoded = canvasEncoded.getContext('2d', { willReadFrequently: true });
         const ctxDecoded = canvasDecoded.getContext('2d', { willReadFrequently: true });
-        let count = 1;
-        let nswitches = 1;
         const processFrame = async () => {
             if (videoTrack.readyState == 'live') {
                 try {
@@ -483,8 +462,9 @@ export default class JitsiRemoteTrack extends JitsiTrack {
                         this.frame.close();
                     }
                     this.frame = await imageCapture.grabFrame();
-                } catch (error) {
-                    logger.info('Decoder: could not caught frame: ', error);
+                } catch (err) {
+                    logger.info('Decoder: could not catch the frame: ', err);
+                    this._animationFrameId = requestAnimationFrame(processFrame);
 
                     return;
                 }
@@ -492,19 +472,24 @@ export default class JitsiRemoteTrack extends JitsiTrack {
                 const nwidth = this.frame.width;
                 const nheight = this.frame.height;
 
-                if (nheight < 240 && !(browser.isSafari()) && !(this.attachon)) {
-                    logger.info('Decoder: Activating decoder for track:', this.stream.getVideoTracks()[0]);
-                    logger.info('Decoder: new resolution: ', nwidth, 'x', nheight, ', track: ', this.stream.getVideoTracks()[0]);
+                if (!nwidth || !nheight) {
+                    logger.warn('Decoder: invalid track dimensions, skipping frame:', 'width:', nwidth, 'height:', nheight);
+                    this._animationFrameId = requestAnimationFrame(processFrame);
+
+                    return;
+                }
+
+                if (nheight < 240 && !this.attachon) {
+                    logger.info('Decoder: Activating decoder for track:', videoTrack, 'new resolution: ', nwidth, 'x', nheight);
                     this.activedecoder = true;
                 }
-                if ((nheight >= 240 && !(this.attachoff)) || browser.isSafari()) {
-                    logger.info('Decoder: Deactivating decoder for track:', this.stream.getVideoTracks()[0]);
-                    logger.info('Decoder: new resolution: ', nwidth, 'x', nheight, ', track: ', this.stream.getVideoTracks()[0]);
+                if (nheight >= 240 && !this.attachoff) {
+                    logger.info('Decoder: Deactivating decoder for track:', videoTrack, 'new resolution: ', nwidth, 'x', nheight);
                     this.activedecoder = false;
                 }
                 // check wether the canvas must be changed
-                if (nwidth > 0 && this.activedecoder && nheight > 0) {
-                    if (this.width != nwidth || this.height != nheight || count % 30 == 0) {
+                if (this.activedecoder) {
+                    if (this.width != nwidth || this.height != nheight) {
                         try {
                             if (this.inputTensor) {
                                 this.inputTensor.dispose();
@@ -520,13 +505,14 @@ export default class JitsiRemoteTrack extends JitsiTrack {
                             this.dataOutput = new ImageData(2 * nwidth, 2 * nheight);
                             this.width = nwidth;
                             this.height = nheight;
-                        } catch {
-                            logger.info('Decoder: Could not set new resolution');
+                        } catch (err) {
+                            logger.info('Decoder: Could not set new resolution', err);
+                            this._animationFrameId = requestAnimationFrame(processFrame);
+
+                            return;
                         }
                     }
-                }
 
-                if ((this.width > 0 && this.activedecoder)) {
                     ctxEncoded.drawImage(this.frame, 0, 0, this.width, this.height);
                     this.frame.close();
                     this.imageEncode = ctxEncoded.getImageData(0, 0, this.width, this.height);
@@ -534,8 +520,8 @@ export default class JitsiRemoteTrack extends JitsiTrack {
 
                     try {
                         this.inputBuffer.set(this.inputData);
-                    } catch (error) {
-                        logger.info('Decoder: float32 buffer could not be set: ', error);
+                    } catch (err) {
+                        logger.info('Decoder: float32 buffer could not be set: ', err);
                         this._animationFrameId = requestAnimationFrame(processFrame);
 
                         return;
@@ -543,8 +529,8 @@ export default class JitsiRemoteTrack extends JitsiTrack {
 
                     try {
                         this.outInference = await decodingSession.run(this.input);
-                    } catch (error) {
-                        logger.info('Decoder: could not run onnx session: ', error);
+                    } catch (err) {
+                        logger.info('Decoder: could not run onnx session: ', err);
                         this._animationFrameId = requestAnimationFrame(processFrame);
 
                         return;
@@ -553,8 +539,8 @@ export default class JitsiRemoteTrack extends JitsiTrack {
                     try {
                         this.dataOutput.data.set(this.outInference.output.data);
                         ctxDecoded.putImageData(this.dataOutput, 0, 0);
-                    } catch (error) {
-                        logger.info('Decoder: output frame could not be set: ', error);
+                    } catch (err) {
+                        logger.info('Decoder: output frame could not be set: ', err);
                         this._animationFrameId = requestAnimationFrame(processFrame);
 
                         return;
@@ -565,7 +551,7 @@ export default class JitsiRemoteTrack extends JitsiTrack {
                     this.outInference.output.dispose();
                     this.outInference = null;
                 }
-                if ((!(this.attachoff) && !(this.activedecoder))) {
+                if (!this.attachoff && !this.activedecoder) {
                     if (container.srcObject) {
                         container.srcObject = null;
                     }
@@ -573,29 +559,16 @@ export default class JitsiRemoteTrack extends JitsiTrack {
                     this.attachon = false;
                     logger.info('Decoder: OFF');
                     RTCUtils.attachMediaStream(container, this.stream);
-                    nswitches += 1;
                 }
-                if ((!(this.attachon) && this.activedecoder)) {
+                if (!this.attachon && this.activedecoder) {
                     if (container.srcObject) {
                         container.srcObject = null;
-                    }
-                    if (nswitches % 20 == 0) {
-                        if (this._decodedTrack) {
-                            this._decodedTrack.stop();
-                        }
-                        if (this._decodedStream) {
-                            this._decodedStream.getTracks().forEach(t => t.stop());
-                        }
-                        this._decodedStream = canvasDecoded.captureStream();
-                        this._decodedTrack = this._decodedStream.getVideoTracks()[0];
                     }
                     this.attachon = true;
                     this.attachoff = false;
                     logger.info('Decoder: ON');
                     RTCUtils.attachMediaStream(container, this._decodedStream);
-                    nswitches += 1;
                 }
-                count = count + 1;
             }
             this._animationFrameId = requestAnimationFrame(processFrame);
         };
@@ -618,7 +591,7 @@ export default class JitsiRemoteTrack extends JitsiTrack {
 
         if (this.stream) {
             this._onTrackAttach(container);
-            if (this.type === MediaType.VIDEO && this.videoType === VideoType.CAMERA && decode && !(browser.isSafari())) {
+            if (this.type === MediaType.VIDEO && this.videoType === VideoType.CAMERA && decode && !browser.isSafari()) {
                 this.increaseResolution(container);
             } else {
                 result = RTCUtils.attachMediaStream(container, this.stream);
@@ -704,10 +677,6 @@ export default class JitsiRemoteTrack extends JitsiTrack {
         if (this.outInference) {
             this.outInference.output.dispose();
             this.outInference = null;
-        }
-        if (this._decodedTrack) {
-            this._decodedTrack.stop();
-            this._decodedTrack = null;
         }
         if (this._decodedStream) {
             this._decodedStream.getTracks().forEach(t => t.stop());

--- a/tests/decoder.spec.ts
+++ b/tests/decoder.spec.ts
@@ -1,0 +1,303 @@
+import JitsiRemoteTrack, { loadDecoder, decodingSession } from '../modules/RTC/JitsiRemoteTrack';
+import { MediaType } from '../service/RTC/MediaType';
+import { VideoType } from '../service/RTC/VideoType';
+import RTC from '../modules/RTC/RTC';
+import { createMockConference } from './mocks';
+import RTCUtils from '../modules/RTC/RTCUtils.js';
+
+const KARMA_MODEL_PATH = '/base/models/RTC/Decoder.onnx';
+
+function makeFakeVideoStream(width = 80, height = 60): { stream: MediaStream; stop: () => void } {
+    const canvas = document.createElement('canvas');
+
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext('2d')!;
+
+    let frame = 0;
+    const id = setInterval(() => {
+        const imageData = ctx.createImageData(width, height);
+
+        for (let i = 0; i < imageData.data.length; i += 4) {
+            const x = (i / 4) % width;
+            const y = Math.floor(i / 4 / width);
+
+            imageData.data[i]     = (x * 3 + frame) % 256;   
+            imageData.data[i + 1] = (y * 3 + frame * 2) % 256;
+            imageData.data[i + 2] = (x + y + frame) % 256;
+            imageData.data[i + 3] = 255;
+        }
+        ctx.putImageData(imageData, 0, 0);
+        frame++;
+    }, 33);
+
+    return {
+        stream: canvas.captureStream(30),
+        stop: () => clearInterval(id),
+    };
+}
+
+function makeTrack(stream: MediaStream): JitsiRemoteTrack {
+    const videoTrack = stream.getVideoTracks()[0];
+    const conferenceMock = createMockConference();
+    const rtc =  new RTC(conferenceMock);
+    
+
+    return new JitsiRemoteTrack(
+        rtc,
+        conferenceMock,
+        'endpoint-1',
+        stream,
+        videoTrack,
+        MediaType.VIDEO,
+        VideoType.CAMERA,
+        12345,
+        false,
+        false,
+        'source-1',
+    );
+}
+
+function waitUntil(predicate: () => boolean, timeoutMs = 2_000, intervalMs = 100): Promise<void> {
+    return new Promise((resolve, reject) => {
+        const start = Date.now();
+        const id = setInterval(() => {
+            if (predicate()) {
+                clearInterval(id);
+                resolve();
+            } else if (Date.now() - start > timeoutMs) {
+                clearInterval(id);
+                reject(new Error(`waitUntil timed out after ${timeoutMs} ms`));
+            }
+        }, intervalMs);
+    });
+}
+
+describe('JitsiRemoteTrack decoder', () => {
+    let stream: MediaStream;
+    let track: JitsiRemoteTrack;
+    let container: HTMLVideoElement;
+
+    let stopStream: () => void;
+
+    beforeAll(async () => {
+        await loadDecoder(KARMA_MODEL_PATH);
+        expect((JitsiRemoteTrack as any).decodingSession).not.toBeNull();
+    }, 30_000);
+
+
+    beforeEach(() => {
+        const fakeStream = makeFakeVideoStream(80, 60);
+        stream = fakeStream.stream;
+        stopStream = fakeStream.stop;
+        track = makeTrack(stream);
+        container = document.createElement('video');
+        container.muted = true;
+        document.body.appendChild(container);
+    });
+
+    afterEach(async () => {
+        stopStream();
+        await track.dispose();
+        container.remove();
+        stream.getTracks().forEach(t => t.stop());
+    });
+
+    describe('memory management', () => {
+
+        it('sets variable when decoder is activated', async () => {
+            track.increaseResolution(container);
+
+            await waitUntil(() => track.isDecoderOn()=== true);
+            expect((track as any)._animationFrameId).toBeGreaterThan(0);
+            expect(track.isDecoderOn()).toBeTrue();
+            expect((track as any).inputTensor !== null).toBeTrue();
+            expect((track as any).activedecoder).toBeTrue();
+            expect((track as any).frame).toBeNull();
+            expect((track as any).dataOutput !== null).toBeTrue();
+            expect((track as any).inputBuffer !== null).toBeTrue();
+            expect((track as any).height !== 0).toBeTrue();
+            expect((track as any).width !== 0).toBeTrue();
+
+        });
+
+        it('clear all variables after clean up is called', async () => {
+            track.increaseResolution(container);
+            await waitUntil(() => track.isDecoderOn()=== true);
+
+            await track.dispose();
+
+            expect((track as any)._animationFrameId).toBeNull();
+            expect(track.isDecoderOn()).toBeFalse();
+            expect((track as any).inputTensor).toBeNull();
+            expect((track as any).frame).toBeNull();
+            expect((track as any).activedecoder).not.toBeTrue();
+            expect((track as any).height === 0).toBeTrue();
+            expect((track as any).width === 0).toBeTrue();
+
+        });
+
+        it('calls dispose() for inputTensor in track dispose()', async () => {
+            track.increaseResolution(container);
+            await waitUntil(() => track.isDecoderOn()=== true);
+
+            const spy = spyOn((track as any).inputTensor, 'dispose').and.callThrough();
+
+            await track.dispose();
+
+            expect(spy).toHaveBeenCalled();
+        });
+
+        it('stops all _decodedStream tracks after dispose()', async () => {
+            track.increaseResolution(container);
+            await waitUntil(() => track.isDecoderOn()=== true);
+
+            const decodedStream: MediaStream = (track as any)._decodedStream;
+            const innerTracks = decodedStream.getTracks();
+
+            await track.dispose();
+
+            innerTracks.forEach(t => {
+                expect(t.readyState).toBe('ended');
+            });
+            expect((track as any)._decodedStream).toBeNull();
+        });
+
+        it('reallocates tensor only when frame dimensions change', async () => {
+            track.increaseResolution(container);
+            await waitUntil(() => track.isDecoderOn()=== true);
+
+            const firstTensor = (track as any).inputTensor;
+
+            await new Promise(r => setTimeout(r, 500));
+            expect((track as any).inputTensor).toBe(firstTensor);
+        });
+
+        it('does not start a new frame while the previous one is still being processed', async () => {
+            const runSpy = spyOn(decodingSession, 'run').and.callThrough();
+            track.increaseResolution(container);
+            await waitUntil(() => track.isDecoderOn() === true);
+            await waitUntil(() => track.isProcessingFrame === false);
+
+            const callsBefore = runSpy.calls.count();
+            track.isProcessingFrame = true;
+            
+            await new Promise(r => setTimeout(r, 300));
+
+            expect(runSpy.calls.count()).toBe(callsBefore);
+            track.isProcessingFrame = false;
+            await waitUntil(() => track.isProcessingFrame === false)
+
+        });
+
+        it('disposes previous inputTensor before allocating a new one on dimension change', async () => {
+            track.increaseResolution(container);
+            await waitUntil(() => track.isDecoderOn() === true);
+
+            const firstTensor = (track as any).inputTensor;
+            const disposeSpy = spyOn(firstTensor, 'dispose').and.callThrough();
+
+            // Trigger dimension change
+            const { stream: differentResStream, stop } = makeFakeVideoStream(160, 120);
+
+            (track as any).stream = differentResStream;
+
+            await waitUntil(() => (track as any).inputTensor !== firstTensor);
+
+            expect(disposeSpy).toHaveBeenCalled();
+
+            await track.dispose();
+            stop();
+        });
+    });
+
+
+    describe('if decoder fails, back to the original track', () => {
+
+        it('if decoder suddenly fails, turns it off and uses original stream', async () => {
+            const attachSpy = spyOn(RTCUtils, 'attachMediaStream').and.callThrough();
+            track.increaseResolution(container);
+            await waitUntil(() => track.isDecoderOn()=== true);
+            const originalStream = (track as any).stream;
+            const decodedStream = (track as any)._decodedStream;
+
+            const ort = require('onnxruntime-web');
+            const badTensor = new ort.Tensor('float32', new Float32Array(0), [ 0, 0, 0, 0 ]);
+
+            (track as any).inputTensor = badTensor;
+
+            await waitUntil(() => track.isDecoderOn()=== false);
+
+            expect((track as any).activedecoder).toBe(false);
+            expect(track.isProcessingFrame).toBe(false);
+            expect(track.isDecoderOn()).toBe(false);
+            expect((track as any)._animationFrameId).not.toBeNull();
+
+            const lastCall = attachSpy.calls.mostRecent();
+            expect(lastCall).toBeDefined();
+            expect(lastCall.args[0]).toBe(container);
+            expect(lastCall.args[1]).toBe(originalStream);
+            expect(lastCall.args[1]).not.toBe(decodedStream);
+        });
+
+        it('does not attach the decoded stream at all if decoder fails on the first frame', async () => {
+
+            const attachSpy = spyOn(RTCUtils, 'attachMediaStream').and.callThrough();
+            const runSpy = spyOn(decodingSession, 'run').and.rejectWith(new Error('injected failure'));
+
+            track.increaseResolution(container);
+            await waitUntil(() => runSpy.calls.count() >= 1);
+        
+
+            expect((track as any).activedecoder).toBe(false);
+            expect(track.isProcessingFrame).toBe(false);
+            expect(track.isDecoderOn()).toBe(false);
+            expect((track as any)._animationFrameId).not.toBeNull();
+
+            expect(attachSpy).not.toHaveBeenCalled();
+        });
+
+        
+        it('turns decoder off and falls back to original stream when resolution rises above 240p', async () => {
+            const attachSpy = spyOn(RTCUtils, 'attachMediaStream').and.callThrough();
+
+            track.increaseResolution(container);
+            await waitUntil(() => track.isDecoderOn() === true);
+
+            const originalStream = (track as any).stream;
+            const decodedStream = (track as any)._decodedStream;
+
+            const { stream: highResStream, stop: stopHighRes } = makeFakeVideoStream(640, 480);
+
+            (track as any).stream = highResStream;
+
+            await waitUntil(() => track.isDecoderOn() === false);
+
+            expect((track as any).activedecoder).toBe(false);
+            expect(track.isDecoderOn()).toBe(false);
+
+            const lastCall = attachSpy.calls.mostRecent();
+
+            expect(lastCall).toBeDefined();
+            expect(lastCall.args[0]).toBe(container);
+            expect(lastCall.args[1]).toBe(highResStream);
+            expect(lastCall.args[1]).not.toBe(originalStream);
+            expect(lastCall.args[1]).not.toBe(decodedStream);
+
+            stopHighRes();
+        });
+
+        it('If processFrame fails, the loop keeps working and tries the next frame', async () => {
+
+            // simulate processFrame failure
+            const grabFrameSpy = jasmine.createSpy('grabFrame').and.rejectWith(new Error('grabFrame injected failure'));
+            spyOn(window as any, 'ImageCapture').and.returnValue({ grabFrame: grabFrameSpy });
+
+            track.increaseResolution(container);
+            await waitUntil(() => grabFrameSpy.calls.count() >= 2);
+
+            expect((track as any)._animationFrameId).not.toBeNull();
+            expect(grabFrameSpy).toHaveBeenCalled();
+        });
+    });
+});

--- a/tests/decoder.spec.ts
+++ b/tests/decoder.spec.ts
@@ -112,7 +112,7 @@ describe('JitsiRemoteTrack decoder', () => {
             expect((track as any)._animationFrameId).toBeGreaterThan(0);
             expect(track.isDecoderOn()).toBeTrue();
             expect((track as any).inputTensor !== null).toBeTrue();
-            expect((track as any).activedecoder).toBeTrue();
+            expect((track as any).shouldDecode).toBeTrue();
             expect((track as any).frame).toBeNull();
             expect((track as any).dataOutput !== null).toBeTrue();
             expect((track as any).inputBuffer !== null).toBeTrue();
@@ -131,7 +131,7 @@ describe('JitsiRemoteTrack decoder', () => {
             expect(track.isDecoderOn()).toBeFalse();
             expect((track as any).inputTensor).toBeNull();
             expect((track as any).frame).toBeNull();
-            expect((track as any).activedecoder).not.toBeTrue();
+            expect((track as any).shouldDecode).not.toBeTrue();
             expect((track as any).height === 0).toBeTrue();
             expect((track as any).width === 0).toBeTrue();
 
@@ -228,7 +228,7 @@ describe('JitsiRemoteTrack decoder', () => {
 
             await waitUntil(() => track.isDecoderOn()=== false);
 
-            expect((track as any).activedecoder).toBe(false);
+            expect((track as any).shouldDecode).toBe(false);
             expect(track.isProcessingFrame).toBe(false);
             expect(track.isDecoderOn()).toBe(false);
             expect((track as any)._animationFrameId).not.toBeNull();
@@ -249,7 +249,7 @@ describe('JitsiRemoteTrack decoder', () => {
             await waitUntil(() => runSpy.calls.count() >= 1);
         
 
-            expect((track as any).activedecoder).toBe(false);
+            expect((track as any).shouldDecode).toBe(false);
             expect(track.isProcessingFrame).toBe(false);
             expect(track.isDecoderOn()).toBe(false);
             expect((track as any)._animationFrameId).not.toBeNull();
@@ -273,7 +273,7 @@ describe('JitsiRemoteTrack decoder', () => {
 
             await waitUntil(() => track.isDecoderOn() === false);
 
-            expect((track as any).activedecoder).toBe(false);
+            expect((track as any).shouldDecode).toBe(false);
             expect(track.isDecoderOn()).toBe(false);
 
             const lastCall = attachSpy.calls.mostRecent();

--- a/tests/decoder.spec.ts
+++ b/tests/decoder.spec.ts
@@ -83,7 +83,7 @@ describe('JitsiRemoteTrack decoder', () => {
     beforeAll(async () => {
         await loadDecoder(KARMA_MODEL_PATH);
         expect((JitsiRemoteTrack as any).decodingSession).not.toBeNull();
-    }, 30_000);
+    }, 1_000);
 
 
     beforeEach(() => {

--- a/tests/decoder.spec.ts
+++ b/tests/decoder.spec.ts
@@ -113,7 +113,6 @@ describe('JitsiRemoteTrack decoder', () => {
             expect(track.isDecoderOn()).toBeTrue();
             expect((track as any).inputTensor !== null).toBeTrue();
             expect((track as any).shouldDecode).toBeTrue();
-            expect((track as any).frame).toBeNull();
             expect((track as any).dataOutput !== null).toBeTrue();
             expect((track as any).inputBuffer !== null).toBeTrue();
             expect((track as any).height !== 0).toBeTrue();
@@ -130,7 +129,6 @@ describe('JitsiRemoteTrack decoder', () => {
             expect((track as any)._animationFrameId).toBeNull();
             expect(track.isDecoderOn()).toBeFalse();
             expect((track as any).inputTensor).toBeNull();
-            expect((track as any).frame).toBeNull();
             expect((track as any).shouldDecode).not.toBeTrue();
             expect((track as any).height === 0).toBeTrue();
             expect((track as any).width === 0).toBeTrue();

--- a/tests/mocks.ts
+++ b/tests/mocks.ts
@@ -162,6 +162,10 @@ export class XmppServerMock {
     }
 }
 
+export function createMockConference() {
+    return mock<JitsiConference>();
+}
+
 export async function createInitializedManagedKeyHandler(
         xmppServerMock: XmppServerMock,
         max_timeout: number,
@@ -171,7 +175,7 @@ export async function createInitializedManagedKeyHandler(
         }> {
     const id = new Date().getTime().toString(16).slice(-8);
 
-    const conferenceMock = mock<JitsiConference>();
+    const conferenceMock = createMockConference();
 
     when(conferenceMock.myUserId()).thenReturn(id);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In some cases, the decoder was terminating on errors without calling requestAnimationFrame for the next frame. This seems to be the root cause of the frozen image/no image issue.

## How Has This Been Tested?

unit tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.