### PR TITLE
[PB-6442] fix orphaned tracks not clening up

### DIFF
--- a/JitsiConference.ts
+++ b/JitsiConference.ts
@@ -3425,6 +3425,8 @@ export default class JitsiConference extends Listenable {
             if (FeatureFlags.isSsrcRewritingSupported()) {
                 track.setSourceName(null);
                 track.setOwner(null);
+                console.warn('Decoder: disposing of an orphand track (tracksToBeRemoved)');
+                track.cleanDecoder();
             }
         });
 

--- a/JitsiConferenceEventManager.ts
+++ b/JitsiConferenceEventManager.ts
@@ -203,7 +203,12 @@ export default class JitsiConferenceEventManager {
                 track.setOwner(owner);
                 track.setSourceName(sourceName);
                 track._setVideoType(videoType);
-                owner && conference.eventEmitter.emit(JitsiConferenceEvents.TRACK_ADDED, track);
+                if (owner) {
+                    conference.eventEmitter.emit(JitsiConferenceEvents.TRACK_ADDED, track);
+                } else {
+                    console.warn('Decoder: disposing of an orphand track (chat room)');
+                    track.cleanDecoder();
+                }
             }
         });
 

--- a/modules/RTC/JitsiRemoteTrack.ts
+++ b/modules/RTC/JitsiRemoteTrack.ts
@@ -85,11 +85,12 @@ export default class JitsiRemoteTrack extends JitsiTrack {
     private inputTensor: Nullable<any> = null;
     private dataOutput: Nullable<ImageData> = null;
     private inputBuffer: Nullable<Float32Array> = null;
+    private wasDisposed: boolean = false;
+    private trackID: string = 'no track ID yet';
 
     public ownerEndpointId: string;
     public isP2P: boolean;
     public rtcId: Nullable<string>;
-    public frame: Nullable<ImageBitmap> = null;
     public width: number = 0;
     public height: number = 0;
     public shouldDecode: boolean = false;
@@ -424,57 +425,88 @@ export default class JitsiRemoteTrack extends JitsiTrack {
      * @param container the HTML container which can be 'video' or 'audio'
      * element.
      */
-    increaseResolution(container: any) {
-        if (this._animationFrameId) cancelAnimationFrame(this._animationFrameId);
+    increaseResolution(container: HTMLElement) {
+        if (this._animationFrameId) {
+            logger.warn('Decoder: canceling animation frame for track:', this.trackID);
+            cancelAnimationFrame(this._animationFrameId);
+        }
         const canvasDecoded = document.createElement('canvas');
 
         this._decodedStream = canvasDecoded.captureStream();
+
+        let videoTrack = this.stream.getVideoTracks()[0];
+
+        this.trackID = videoTrack.id;
+
+        logger.info('Decoder: start increase resolution for track:', this.trackID, 'corresponding to', this.getParticipantId());
+        // Frame-grabber to catch frames from the incoming stream
+        let imageCapture = new ImageCapture(videoTrack);
+        // Setting up the aux canvas to paint the caught frames
         // Extracting track from canvas-sender
         const canvasEncoded = document.createElement('canvas');
         const ctxEncoded = canvasEncoded.getContext('2d', { willReadFrequently: true });
         const ctxDecoded = canvasDecoded.getContext('2d', { willReadFrequently: true });
 
         this.isProcessingFrame = false;
+        this.wasDisposed = false;
         const processFrame = async () => {
+            if (!this.getParticipantId()) {
+                logger.error('Decoder: Was called for an orphaned track! Cleaning up..');
 
+                if (this.decoderIsOn) RTCUtils.attachMediaStream(container, this.stream);
+                this.cleanDecoder();
+
+                return;
+
+            }
+            if (this.wasDisposed) {
+                logger.warn('Decoder: stopping because disposed was called for this track:', this.trackID);
+
+                return;
+            }
             if (this.isProcessingFrame) {
-                logger.warn('Decoder: skipping a frame because the previous one is still being processed');
+                logger.warn('Decoder: skipping a frame because the previous one is still being processed for track', this.trackID);
                 this._animationFrameId = requestAnimationFrame(processFrame);
 
                 return;
             }
 
-            const videoTrack = this.stream.getVideoTracks()[0];
-            // Frame-grabber to catch frames from the incoming stream
-            const imageCapture = new ImageCapture(videoTrack);
-            // Setting up the aux canvas to paint the caught frames
+            const currentVideoTrack = this.stream.getVideoTracks()[0];
+
+            if (videoTrack !== currentVideoTrack) {
+                console.log('Decoder: changing video track and image capture due to track change');
+
+                videoTrack = currentVideoTrack;
+                imageCapture = new ImageCapture(videoTrack);
+            }
 
             if (videoTrack.readyState === 'live') {
-                let outInference: Nullable<any>;
+                let outInference: Nullable<any> = null;
+                let frame: ImageBitmap | null = null;
 
                 try {
                     this.isProcessingFrame = true;
                     try {
-                        this.frame = await imageCapture.grabFrame();
+                        frame = await imageCapture.grabFrame();
                     } catch (err) {
-                        logger.warn('Decoder: could not catch the frame: ', err);
-                        throw new Error('Decoder: could not catch the frame');
+                        logger.warn('Decoder: could not catch the frame for track:', this.trackID, 'corresponding to', this.getParticipantId(), 'error:', err);
+                        throw new Error('Decoder: could not catch the frame for track:' + this.trackID);
                     }
                     // Getting the current size of the incoming stream
-                    const nwidth = this.frame.width;
-                    const nheight = this.frame.height;
+                    const nwidth = frame.width;
+                    const nheight = frame.height;
 
                     if (!nwidth || !nheight) {
-                        logger.warn('Decoder: invalid track dimensions, skipping frame:', 'width:', nwidth, 'height:', nheight);
-                        throw new Error('Decoder: invalid track dimensions, skipping frame');
+                        logger.warn('Decoder: invalid track dimensions, skipping frame for track', this.trackID, 'width:', nwidth, 'height:', nheight);
+                        throw new Error('Decoder: invalid track dimensions, skipping frame for track:' + this.trackID);
                     }
 
                     if (nheight < 240 && !this.decoderIsOn) {
-                        logger.info('Decoder: Activating decoder for track:', videoTrack, 'new resolution: ', nwidth, 'x', nheight);
+                        logger.info('Decoder: Activating decoder for track:', this.trackID, 'frame resolution: ', nwidth, 'x', nheight);
                         this.shouldDecode = true;
                     }
                     if (nheight >= 240 && this.decoderIsOn) {
-                        logger.info('Decoder: Deactivating decoder for track:', videoTrack, 'new resolution: ', nwidth, 'x', nheight);
+                        logger.info('Decoder: Deactivating decoder for track:', this.trackID, 'frame resolution: ', nwidth, 'x', nheight);
                         this.shouldDecode = false;
                     }
                     if (this.shouldDecode) {
@@ -495,45 +527,45 @@ export default class JitsiRemoteTrack extends JitsiTrack {
                                 this.width = nwidth;
                                 this.height = nheight;
                             } catch (err) {
-                                logger.error('Decoder: Could not set new resolution', err);
-                                throw new Error('Decoder: Could not set new resolution');
+                                logger.error('Decoder: Could not set new resolution for track:', this.trackID, 'error:', err);
+                                throw new Error('Decoder: Could not set new resolution for track' + this.trackID);
                             }
                         }
-                        ctxEncoded.drawImage(this.frame, 0, 0, this.width, this.height);
+                        ctxEncoded.drawImage(frame, 0, 0, this.width, this.height);
                         const imageEncode = ctxEncoded.getImageData(0, 0, this.width, this.height);
 
                         try {
                             this.inputBuffer.set(imageEncode.data);
                         } catch (err) {
-                            logger.error('Decoder: float32 buffer could not be set: ', err);
+                            logger.error('Decoder: float32 buffer could not be set for track:', this.trackID, 'error:', err);
                             throw new Error('Decoder: float32 buffer could not be set');
                         }
 
                         try {
                             outInference = await decodingSession.run({ input: this.inputTensor });
                         } catch (err) {
-                            logger.error('Decoder: could not run onnx session: ', err);
+                            logger.error('Decoder: could not run onnx session for track:', this.trackID, 'error:', err);
                             throw new Error('Decoder: could not run onnx session');
                         }
                         try {
                             this.dataOutput.data.set(outInference.output.data);
                             ctxDecoded.putImageData(this.dataOutput, 0, 0);
                         } catch (err) {
-                            logger.error('Decoder: could not set output frame: ', err);
+                            logger.error('Decoder: could not set output frame for track:', this.trackID, 'error:', err);
                             throw new Error('Decoder: could not set output frame');
                         }
 
                         if (!this.decoderIsOn) {
                             this.decoderIsOn = true;
-                            logger.info('Decoder: ON');
+                            logger.info('Decoder: ON for track:', this.trackID);
                             RTCUtils.attachMediaStream(container, this._decodedStream);
                         }
                     }
                 } catch (error) {
                     this.shouldDecode = false;
                 } finally {
-                    this.frame?.close();
-                    this.frame = null;
+                    frame?.close();
+                    frame = null;
                     outInference?.output.dispose();
                     outInference = null;
                     this.isProcessingFrame = false;
@@ -541,11 +573,17 @@ export default class JitsiRemoteTrack extends JitsiTrack {
 
                 if (this.decoderIsOn && !this.shouldDecode) {
                     this.decoderIsOn = false;
-                    logger.info('Decoder: OFF');
+                    logger.info('Decoder: OFF for track', this.trackID);
                     RTCUtils.attachMediaStream(container, this.stream);
                 }
             }
-            this._animationFrameId = requestAnimationFrame(processFrame);
+            if (this.wasDisposed) {
+                logger.info('Decoder: Finished processing frame and track was already disposed, clean up just in case');
+                if (this.decoderIsOn) RTCUtils.attachMediaStream(container, this.stream);
+                this.cleanDecoder();
+
+                return;
+            } else this._animationFrameId = requestAnimationFrame(processFrame);
 
         };
 
@@ -567,10 +605,9 @@ export default class JitsiRemoteTrack extends JitsiTrack {
 
         if (this.stream) {
             this._onTrackAttach(container);
+            result = RTCUtils.attachMediaStream(container, this.stream);
             if (this.type === MediaType.VIDEO && this.videoType === VideoType.CAMERA && decode && !browser.isSafari()) {
                 this.increaseResolution(container);
-            } else {
-                result = RTCUtils.attachMediaStream(container, this.stream);
             }
         }
         this.containers.push(container);
@@ -631,20 +668,11 @@ export default class JitsiRemoteTrack extends JitsiTrack {
         return this._enteredForwardedSourcesTimestamp;
     }
 
-    /**
-     * Removes attached event listeners and dispose TrackStreamingStatus .
-     *
-     * @returns {Promise}
-     */
-    override async dispose(): Promise<void> {
-        logger.info('Decoder: cleaning');
+    cleanDecoder() {
+        logger.info('Decoder: cleaning is called for track:', this.trackID);
         if (this._animationFrameId !== null) {
             cancelAnimationFrame(this._animationFrameId);
             this._animationFrameId = null;
-        }
-        if (this.frame) {
-            this.frame.close();
-            this.frame = null;
         }
         if (this.inputTensor) {
             this.inputTensor.dispose();
@@ -660,7 +688,22 @@ export default class JitsiRemoteTrack extends JitsiTrack {
         this.width = 0;
         this.height = 0;
         this.dataOutput = null;
-        this.inputBuffer = null;
+        this.wasDisposed = true;
+
+    }
+
+    /**
+     * Removes attached event listeners and dispose TrackStreamingStatus .
+     *
+     * @returns {Promise}
+     */
+    override async dispose(): Promise<void> {
+
+        if (this.type === MediaType.VIDEO && this.videoType === VideoType.CAMERA && !browser.isSafari() && !this.wasDisposed) {
+            console.log('Decoder: dispose called');
+            this.cleanDecoder();
+        }
+
         if (this.disposed) {
             return;
         }

--- a/tests/decoder.spec.ts
+++ b/tests/decoder.spec.ts
@@ -113,7 +113,6 @@ describe('JitsiRemoteTrack decoder', () => {
             expect(track.isDecoderOn()).toBeTrue();
             expect((track as any).inputTensor !== null).toBeTrue();
             expect((track as any).shouldDecode).toBeTrue();
-            expect((track as any).frame).toBeNull();
             expect((track as any).dataOutput !== null).toBeTrue();
             expect((track as any).inputBuffer !== null).toBeTrue();
             expect((track as any).height !== 0).toBeTrue();
@@ -130,7 +129,6 @@ describe('JitsiRemoteTrack decoder', () => {
             expect((track as any)._animationFrameId).toBeNull();
             expect(track.isDecoderOn()).toBeFalse();
             expect((track as any).inputTensor).toBeNull();
-            expect((track as any).frame).toBeNull();
             expect((track as any).shouldDecode).not.toBeTrue();
             expect((track as any).height === 0).toBeTrue();
             expect((track as any).width === 0).toBeTrue();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The decoder kept running for tracks after they were orphaned (the track's participant ID was set to undefined). It happened due to how Jitsi works (it just removes ownership and waits for tracks to be cleaned up). Unfortunately, the decoder was not stopped, kept running and probably prevented auto-cleanup. This is fixed now.

Also, I removed frame from class members because it's just a loop variable and it's cleaned up in the final block anyway.


P.S. if (videoTrack !== currentVideoTrack) is mostly for tests, but can also be triggered by the browser swapping tracks instead of re-creating them

## How Has This Been Tested?

QA in local


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.