### PR TITLE
[PB-6488] Do not switch between tracks

### DIFF
--- a/modules/RTC/JitsiRemoteTrack.ts
+++ b/modules/RTC/JitsiRemoteTrack.ts
@@ -433,16 +433,18 @@ export default class JitsiRemoteTrack extends JitsiTrack {
         const canvasDecoded = document.createElement('canvas');
 
         this._decodedStream = canvasDecoded.captureStream();
+        RTCUtils.attachMediaStream(container, this._decodedStream);
 
-        let videoTrack = this.stream.getVideoTracks()[0];
+        const rawVideo = document.createElement('video');
 
-        this.trackID = videoTrack.id;
+        rawVideo.srcObject = this.stream;
+        rawVideo.muted = true;
+        rawVideo.play().catch(() => { /* ignore */ });
+
+        this.trackID = this.stream.getVideoTracks()[0].id;
 
         logger.info('Decoder: start increase resolution for track:', this.trackID, 'corresponding to', this.getParticipantId());
-        // Frame-grabber to catch frames from the incoming stream
-        let imageCapture = new ImageCapture(videoTrack);
-        // Setting up the aux canvas to paint the caught frames
-        // Extracting track from canvas-sender
+
         const canvasEncoded = document.createElement('canvas');
         const ctxEncoded = canvasEncoded.getContext('2d', { willReadFrequently: true });
         const ctxDecoded = canvasDecoded.getContext('2d', { willReadFrequently: true });
@@ -452,8 +454,6 @@ export default class JitsiRemoteTrack extends JitsiTrack {
         const processFrame = async () => {
             if (!this.getParticipantId()) {
                 logger.error('Decoder: Was called for an orphaned track! Cleaning up..');
-
-                if (this.decoderIsOn) RTCUtils.attachMediaStream(container, this.stream);
                 this.cleanDecoder();
 
                 return;
@@ -471,115 +471,99 @@ export default class JitsiRemoteTrack extends JitsiTrack {
                 return;
             }
 
-            const currentVideoTrack = this.stream.getVideoTracks()[0];
+            if (!rawVideo.videoWidth || !rawVideo.videoHeight || rawVideo.readyState < 2) {
+                this._animationFrameId = requestAnimationFrame(processFrame);
 
-            if (videoTrack !== currentVideoTrack) {
-                console.log('Decoder: changing video track and image capture due to track change');
-
-                videoTrack = currentVideoTrack;
-                imageCapture = new ImageCapture(videoTrack);
+                return;
             }
 
-            if (videoTrack.readyState === 'live') {
-                let outInference: Nullable<any> = null;
-                let frame: ImageBitmap | null = null;
+            let outInference: Nullable<any> = null;
 
+            this.isProcessingFrame = true;
+
+            // Getting the current size of the incoming stream
+            const nwidth = rawVideo.videoWidth;
+            const nheight = rawVideo.videoHeight;
+
+            if (nheight < 240 && !this.decoderIsOn) {
+                logger.info('Decoder: Activating decoder for track:', this.trackID, 'frame resolution: ', nwidth, 'x', nheight);
+                this.shouldDecode = true;
+            }
+            if (nheight >= 240 && this.decoderIsOn) {
+                logger.info('Decoder: Deactivating decoder for track:', this.trackID, 'frame resolution: ', nwidth, 'x', nheight);
+                this.shouldDecode = false;
+            }
+            if (this.shouldDecode) {
                 try {
-                    this.isProcessingFrame = true;
-                    try {
-                        frame = await imageCapture.grabFrame();
-                    } catch (err) {
-                        logger.warn('Decoder: could not catch the frame for track:', this.trackID, 'corresponding to', this.getParticipantId(), 'error:', err);
-                        throw new Error('Decoder: could not catch the frame for track:' + this.trackID);
-                    }
-                    // Getting the current size of the incoming stream
-                    const nwidth = frame.width;
-                    const nheight = frame.height;
-
-                    if (!nwidth || !nheight) {
-                        logger.warn('Decoder: invalid track dimensions, skipping frame for track', this.trackID, 'width:', nwidth, 'height:', nheight);
-                        throw new Error('Decoder: invalid track dimensions, skipping frame for track:' + this.trackID);
-                    }
-
-                    if (nheight < 240 && !this.decoderIsOn) {
-                        logger.info('Decoder: Activating decoder for track:', this.trackID, 'frame resolution: ', nwidth, 'x', nheight);
-                        this.shouldDecode = true;
-                    }
-                    if (nheight >= 240 && this.decoderIsOn) {
-                        logger.info('Decoder: Deactivating decoder for track:', this.trackID, 'frame resolution: ', nwidth, 'x', nheight);
-                        this.shouldDecode = false;
-                    }
-                    if (this.shouldDecode) {
-                        // check wether the canvas must be changed
-                        if (this.width != nwidth || this.height != nheight || !this.dataOutput || !this.inputBuffer) {
-                            try {
-                                if (this.inputTensor) {
-                                    this.inputTensor.dispose();
-                                    this.inputTensor = null;
-                                }
-                                canvasEncoded.width = nwidth;
-                                canvasEncoded.height = nheight;
-                                canvasDecoded.width = nwidth * 2;
-                                canvasDecoded.height = nheight * 2;
-                                this.inputBuffer = new Float32Array(nwidth * nheight * 4);
-                                this.inputTensor = new ort.Tensor('float32', this.inputBuffer, [ 1, nheight, nwidth, 4 ]);
-                                this.dataOutput = new ImageData(2 * nwidth, 2 * nheight);
-                                this.width = nwidth;
-                                this.height = nheight;
-                            } catch (err) {
-                                logger.error('Decoder: Could not set new resolution for track:', this.trackID, 'error:', err);
-                                throw new Error('Decoder: Could not set new resolution for track' + this.trackID);
+                    // check wether the canvas must be changed
+                    if (this.width != nwidth || this.height != nheight || !this.dataOutput || !this.inputBuffer) {
+                        try {
+                            if (this.inputTensor) {
+                                this.inputTensor.dispose();
+                                this.inputTensor = null;
                             }
-                        }
-                        ctxEncoded.drawImage(frame, 0, 0, this.width, this.height);
-                        const imageEncode = ctxEncoded.getImageData(0, 0, this.width, this.height);
-
-                        try {
-                            this.inputBuffer.set(imageEncode.data);
+                            canvasEncoded.width = nwidth;
+                            canvasEncoded.height = nheight;
+                            canvasDecoded.width = nwidth * 2;
+                            canvasDecoded.height = nheight * 2;
+                            this.inputBuffer = new Float32Array(nwidth * nheight * 4);
+                            this.inputTensor = new ort.Tensor('float32', this.inputBuffer, [ 1, nheight, nwidth, 4 ]);
+                            this.dataOutput = new ImageData(2 * nwidth, 2 * nheight);
+                            this.width = nwidth;
+                            this.height = nheight;
                         } catch (err) {
-                            logger.error('Decoder: float32 buffer could not be set for track:', this.trackID, 'error:', err);
-                            throw new Error('Decoder: float32 buffer could not be set');
+                            logger.error('Decoder: Could not set new resolution for track:', this.trackID, 'error:', err);
+                            throw new Error('Decoder: Could not set new resolution for track' + this.trackID);
                         }
+                    }
+                    ctxEncoded.drawImage(rawVideo, 0, 0, this.width, this.height);
+                    const imageEncode = ctxEncoded.getImageData(0, 0, this.width, this.height);
 
-                        try {
-                            outInference = await decodingSession.run({ input: this.inputTensor });
-                        } catch (err) {
-                            logger.error('Decoder: could not run onnx session for track:', this.trackID, 'error:', err);
-                            throw new Error('Decoder: could not run onnx session');
-                        }
-                        try {
-                            this.dataOutput.data.set(outInference.output.data);
-                            ctxDecoded.putImageData(this.dataOutput, 0, 0);
-                        } catch (err) {
-                            logger.error('Decoder: could not set output frame for track:', this.trackID, 'error:', err);
-                            throw new Error('Decoder: could not set output frame');
-                        }
+                    try {
+                        this.inputBuffer.set(imageEncode.data);
+                    } catch (err) {
+                        logger.error('Decoder: float32 buffer could not be set for track:', this.trackID, 'error:', err);
+                        throw new Error('Decoder: float32 buffer could not be set');
+                    }
 
-                        if (!this.decoderIsOn) {
-                            this.decoderIsOn = true;
-                            logger.info('Decoder: ON for track:', this.trackID);
-                            RTCUtils.attachMediaStream(container, this._decodedStream);
-                        }
+                    try {
+                        outInference = await decodingSession.run({ input: this.inputTensor });
+                    } catch (err) {
+                        logger.error('Decoder: could not run onnx session for track:', this.trackID, 'error:', err);
+                        throw new Error('Decoder: could not run onnx session');
+                    }
+                    try {
+                        this.dataOutput.data.set(outInference.output.data);
+                        ctxDecoded.putImageData(this.dataOutput, 0, 0);
+                    } catch (err) {
+                        logger.error('Decoder: could not set output frame for track:', this.trackID, 'error:', err);
+                        throw new Error('Decoder: could not set output frame');
+                    }
+
+                    if (!this.decoderIsOn) {
+                        this.decoderIsOn = true;
+                        logger.info('Decoder: ON for track:', this.trackID);
                     }
                 } catch (error) {
                     this.shouldDecode = false;
                 } finally {
-                    frame?.close();
-                    frame = null;
                     outInference?.output.dispose();
                     outInference = null;
                     this.isProcessingFrame = false;
                 }
-
-                if (this.decoderIsOn && !this.shouldDecode) {
+            }
+            if (!this.shouldDecode) {
+                canvasDecoded.width = rawVideo.videoWidth;
+                canvasDecoded.height = rawVideo.videoHeight;
+                ctxDecoded.drawImage(rawVideo, 0, 0, rawVideo.videoWidth, rawVideo.videoHeight);
+                if (this.decoderIsOn) {
                     this.decoderIsOn = false;
-                    logger.info('Decoder: OFF for track', this.trackID);
-                    RTCUtils.attachMediaStream(container, this.stream);
+                    logger.info('Decoder: OFF for track:', this.trackID);
                 }
+                this.isProcessingFrame = false;
             }
             if (this.wasDisposed) {
                 logger.info('Decoder: Finished processing frame and track was already disposed, clean up just in case');
-                if (this.decoderIsOn) RTCUtils.attachMediaStream(container, this.stream);
                 this.cleanDecoder();
 
                 return;
@@ -605,9 +589,10 @@ export default class JitsiRemoteTrack extends JitsiTrack {
 
         if (this.stream) {
             this._onTrackAttach(container);
-            result = RTCUtils.attachMediaStream(container, this.stream);
             if (this.type === MediaType.VIDEO && this.videoType === VideoType.CAMERA && decode && !browser.isSafari()) {
                 this.increaseResolution(container);
+            } else {
+                result = RTCUtils.attachMediaStream(container, this.stream);
             }
         }
         this.containers.push(container);

--- a/modules/RTC/JitsiRemoteTrack.ts
+++ b/modules/RTC/JitsiRemoteTrack.ts
@@ -478,7 +478,7 @@ export default class JitsiRemoteTrack extends JitsiTrack {
                 return;
             }
 
-            if (!this._rawVideo.videoWidth || !this._rawVideo.videoHeight || this._rawVideo.readyState < 2) {
+            if (!this._rawVideo.videoWidth || !this._rawVideo.videoHeight || this._rawVideo.readyState < HTMLMediaElement.HAVE_CURRENT_DATA) {
                 this._animationFrameId = requestAnimationFrame(processFrame);
 
                 return;
@@ -490,7 +490,14 @@ export default class JitsiRemoteTrack extends JitsiTrack {
             const nwidth = this._rawVideo.videoWidth;
             const nheight = this._rawVideo.videoHeight;
 
-            this.shouldDecode = nheight < 240 ? true : false;
+            if (nheight < 240 && !this.decoderIsOn) {
+                logger.info('Decoder: Activating decoder for track:', this.trackID, 'frame resolution: ', nwidth, 'x', nheight);
+                this.shouldDecode = true;
+            }
+            if (nheight >= 240 && this.decoderIsOn) {
+                logger.info('Decoder: Deactivating decoder for track:', this.trackID, 'frame resolution: ', nwidth, 'x', nheight);
+                this.shouldDecode = false;
+            }
 
             if (this.shouldDecode) {
                 try {
@@ -521,7 +528,7 @@ export default class JitsiRemoteTrack extends JitsiTrack {
 
                     if (!this.decoderIsOn) {
                         this.decoderIsOn = true;
-                        logger.info('Decoder: ON for track:', this.trackID, 'current frame resolution: ', nwidth, 'x', nheight);
+                        logger.info('Decoder: ON for track:', this.trackID);
                     }
                 } catch (error) {
                     this.shouldDecode = false;
@@ -537,7 +544,7 @@ export default class JitsiRemoteTrack extends JitsiTrack {
                 ctxDecoded.drawImage(this._rawVideo, 0, 0, this._rawVideo.videoWidth, this._rawVideo.videoHeight);
                 if (this.decoderIsOn) {
                     this.decoderIsOn = false;
-                    logger.info('Decoder: OFF decoder for track:', this.trackID, 'current frame resolution: ', nwidth, 'x', nheight);
+                    logger.info('Decoder: OFF for track', this.trackID);
                 }
                 this.isProcessingFrame = false;
             }

--- a/modules/RTC/JitsiRemoteTrack.ts
+++ b/modules/RTC/JitsiRemoteTrack.ts
@@ -87,6 +87,7 @@ export default class JitsiRemoteTrack extends JitsiTrack {
     private inputBuffer: Nullable<Float32Array> = null;
     private wasDisposed: boolean = false;
     private trackID: string = 'no track ID yet';
+    private _rawVideo: Nullable<HTMLVideoElement> = null;
 
     public ownerEndpointId: string;
     public isP2P: boolean;
@@ -435,11 +436,11 @@ export default class JitsiRemoteTrack extends JitsiTrack {
         this._decodedStream = canvasDecoded.captureStream();
         RTCUtils.attachMediaStream(container, this._decodedStream);
 
-        const rawVideo = document.createElement('video');
+        this._rawVideo = document.createElement('video');
 
-        rawVideo.srcObject = this.stream;
-        rawVideo.muted = true;
-        rawVideo.play().catch(() => { /* ignore */ });
+        this._rawVideo.srcObject = this.stream;
+        this._rawVideo.muted = true;
+        this._rawVideo.play().catch(() => { /* ignore */ });
 
         this.trackID = this.stream.getVideoTracks()[0].id;
 
@@ -448,6 +449,12 @@ export default class JitsiRemoteTrack extends JitsiTrack {
         const canvasEncoded = document.createElement('canvas');
         const ctxEncoded = canvasEncoded.getContext('2d', { willReadFrequently: true });
         const ctxDecoded = canvasDecoded.getContext('2d', { willReadFrequently: true });
+
+        if (!this._rawVideo || !ctxEncoded || !ctxDecoded) {
+            logger.warn('Decoder: stopping because rack was not initialized correctly:', this.trackID);
+
+            return;
+        }
 
         this.isProcessingFrame = false;
         this.wasDisposed = false;
@@ -459,7 +466,7 @@ export default class JitsiRemoteTrack extends JitsiTrack {
                 return;
 
             }
-            if (this.wasDisposed) {
+            if (this.wasDisposed || !this._rawVideo) {
                 logger.warn('Decoder: stopping because disposed was called for this track:', this.trackID);
 
                 return;
@@ -471,7 +478,7 @@ export default class JitsiRemoteTrack extends JitsiTrack {
                 return;
             }
 
-            if (!rawVideo.videoWidth || !rawVideo.videoHeight || rawVideo.readyState < 2) {
+            if (!this._rawVideo.videoWidth || !this._rawVideo.videoHeight || this._rawVideo.readyState < 2) {
                 this._animationFrameId = requestAnimationFrame(processFrame);
 
                 return;
@@ -480,69 +487,41 @@ export default class JitsiRemoteTrack extends JitsiTrack {
             let outInference: Nullable<any> = null;
 
             this.isProcessingFrame = true;
+            const nwidth = this._rawVideo.videoWidth;
+            const nheight = this._rawVideo.videoHeight;
 
-            // Getting the current size of the incoming stream
-            const nwidth = rawVideo.videoWidth;
-            const nheight = rawVideo.videoHeight;
+            this.shouldDecode = nheight < 240 ? true : false;
 
-            if (nheight < 240 && !this.decoderIsOn) {
-                logger.info('Decoder: Activating decoder for track:', this.trackID, 'frame resolution: ', nwidth, 'x', nheight);
-                this.shouldDecode = true;
-            }
-            if (nheight >= 240 && this.decoderIsOn) {
-                logger.info('Decoder: Deactivating decoder for track:', this.trackID, 'frame resolution: ', nwidth, 'x', nheight);
-                this.shouldDecode = false;
-            }
             if (this.shouldDecode) {
                 try {
                     // check wether the canvas must be changed
                     if (this.width != nwidth || this.height != nheight || !this.dataOutput || !this.inputBuffer) {
-                        try {
-                            if (this.inputTensor) {
-                                this.inputTensor.dispose();
-                                this.inputTensor = null;
-                            }
-                            canvasEncoded.width = nwidth;
-                            canvasEncoded.height = nheight;
-                            canvasDecoded.width = nwidth * 2;
-                            canvasDecoded.height = nheight * 2;
-                            this.inputBuffer = new Float32Array(nwidth * nheight * 4);
-                            this.inputTensor = new ort.Tensor('float32', this.inputBuffer, [ 1, nheight, nwidth, 4 ]);
-                            this.dataOutput = new ImageData(2 * nwidth, 2 * nheight);
-                            this.width = nwidth;
-                            this.height = nheight;
-                        } catch (err) {
-                            logger.error('Decoder: Could not set new resolution for track:', this.trackID, 'error:', err);
-                            throw new Error('Decoder: Could not set new resolution for track' + this.trackID);
+                        if (this.inputTensor) {
+                            this.inputTensor.dispose();
+                            this.inputTensor = null;
                         }
+                        canvasEncoded.width = nwidth;
+                        canvasEncoded.height = nheight;
+                        canvasDecoded.width = nwidth * 2;
+                        canvasDecoded.height = nheight * 2;
+                        this.inputBuffer = new Float32Array(nwidth * nheight * 4);
+                        this.inputTensor = new ort.Tensor('float32', this.inputBuffer, [ 1, nheight, nwidth, 4 ]);
+                        this.dataOutput = new ImageData(2 * nwidth, 2 * nheight);
+                        this.width = nwidth;
+                        this.height = nheight;
                     }
-                    ctxEncoded.drawImage(rawVideo, 0, 0, this.width, this.height);
+
+                    ctxEncoded.drawImage(this._rawVideo, 0, 0, this.width, this.height);
                     const imageEncode = ctxEncoded.getImageData(0, 0, this.width, this.height);
 
-                    try {
-                        this.inputBuffer.set(imageEncode.data);
-                    } catch (err) {
-                        logger.error('Decoder: float32 buffer could not be set for track:', this.trackID, 'error:', err);
-                        throw new Error('Decoder: float32 buffer could not be set');
-                    }
-
-                    try {
-                        outInference = await decodingSession.run({ input: this.inputTensor });
-                    } catch (err) {
-                        logger.error('Decoder: could not run onnx session for track:', this.trackID, 'error:', err);
-                        throw new Error('Decoder: could not run onnx session');
-                    }
-                    try {
-                        this.dataOutput.data.set(outInference.output.data);
-                        ctxDecoded.putImageData(this.dataOutput, 0, 0);
-                    } catch (err) {
-                        logger.error('Decoder: could not set output frame for track:', this.trackID, 'error:', err);
-                        throw new Error('Decoder: could not set output frame');
-                    }
+                    this.inputBuffer.set(imageEncode.data);
+                    outInference = await decodingSession.run({ input: this.inputTensor });
+                    this.dataOutput.data.set(outInference.output.data);
+                    ctxDecoded.putImageData(this.dataOutput, 0, 0);
 
                     if (!this.decoderIsOn) {
                         this.decoderIsOn = true;
-                        logger.info('Decoder: ON for track:', this.trackID);
+                        logger.info('Decoder: ON for track:', this.trackID, 'current frame resolution: ', nwidth, 'x', nheight);
                     }
                 } catch (error) {
                     this.shouldDecode = false;
@@ -553,12 +532,12 @@ export default class JitsiRemoteTrack extends JitsiTrack {
                 }
             }
             if (!this.shouldDecode) {
-                canvasDecoded.width = rawVideo.videoWidth;
-                canvasDecoded.height = rawVideo.videoHeight;
-                ctxDecoded.drawImage(rawVideo, 0, 0, rawVideo.videoWidth, rawVideo.videoHeight);
+                canvasDecoded.width = this._rawVideo.videoWidth;
+                canvasDecoded.height = this._rawVideo.videoHeight;
+                ctxDecoded.drawImage(this._rawVideo, 0, 0, this._rawVideo.videoWidth, this._rawVideo.videoHeight);
                 if (this.decoderIsOn) {
                     this.decoderIsOn = false;
-                    logger.info('Decoder: OFF for track:', this.trackID);
+                    logger.info('Decoder: OFF decoder for track:', this.trackID, 'current frame resolution: ', nwidth, 'x', nheight);
                 }
                 this.isProcessingFrame = false;
             }
@@ -658,6 +637,11 @@ export default class JitsiRemoteTrack extends JitsiTrack {
         if (this._animationFrameId !== null) {
             cancelAnimationFrame(this._animationFrameId);
             this._animationFrameId = null;
+        }
+        if (this._rawVideo) {
+            this._rawVideo.pause();
+            this._rawVideo.srcObject = null;
+            this._rawVideo = null;
         }
         if (this.inputTensor) {
             this.inputTensor.dispose();

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "emoji-regex": "10.4.0",
         "jwt-decode": "4.0.0",
         "lodash-es": "4.18.1",
-        "onnxruntime-web": "=1.23.0",
+        "onnxruntime-web": "=1.27.0",
         "sdp-transform": "2.3.0",
         "strophe.js": "https://github.com/jitsi/strophejs/releases/download/v1.5-jitsi-3/strophe.js-1.5.0.tgz",
         "uuid": "14.0.0",
@@ -7269,21 +7269,21 @@
       }
     },
     "node_modules/onnxruntime-common": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.23.0.tgz",
-      "integrity": "sha512-Auz8S9D7vpF8ok7fzTobvD1XdQDftRf/S7pHmjeCr3Xdymi4z1C7zx4vnT6nnUjbpelZdGwda0BmWHCCTMKUTg==",
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.27.0.tgz",
+      "integrity": "sha512-3KxL5wIVqa8Ex08jxSzncm9CMgw8CjOFyOQ7SxvG9o0cVLlhTNKXyIQuTbtX4tGPJEf73OER2xrjt4HJSBL4ow==",
       "license": "MIT"
     },
     "node_modules/onnxruntime-web": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.23.0.tgz",
-      "integrity": "sha512-w0bvC2RwDxphOUFF8jFGZ/dYw+duaX20jM6V4BIZJPCfK4QuCpB/pVREV+hjYbT3x4hyfa2ZbTaWx4e1Vot0fQ==",
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.27.0.tgz",
+      "integrity": "sha512-ogDLsqIozHZwifPuN37OproAo0byX6t43/bP8GzeZWBWD6MOGExswFAx3up4NS/vvWBOg2u2PXomDt3rMmdQSg==",
       "license": "MIT",
       "dependencies": {
         "flatbuffers": "^25.1.24",
         "guid-typescript": "^1.0.9",
         "long": "^5.2.3",
-        "onnxruntime-common": "1.23.0",
+        "onnxruntime-common": "1.27.0",
         "platform": "^1.3.6",
         "protobufjs": "^7.2.4"
       }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "emoji-regex": "10.4.0",
     "jwt-decode": "4.0.0",
     "lodash-es": "4.18.1",
-    "onnxruntime-web": "=1.23.0",
+    "onnxruntime-web": "=1.27.0",
     "sdp-transform": "2.3.0",
     "strophe.js": "https://github.com/jitsi/strophejs/releases/download/v1.5-jitsi-3/strophe.js-1.5.0.tgz",
     "uuid": "14.0.0",

--- a/tests/decoder.spec.ts
+++ b/tests/decoder.spec.ts
@@ -132,6 +132,7 @@ describe('JitsiRemoteTrack decoder', () => {
             expect((track as any).shouldDecode).not.toBeTrue();
             expect((track as any).height === 0).toBeTrue();
             expect((track as any).width === 0).toBeTrue();
+            expect((track as any)._rawVideo).toBeNull();
 
         });
 
@@ -198,7 +199,7 @@ describe('JitsiRemoteTrack decoder', () => {
             // Trigger dimension change
             const { stream: differentResStream, stop } = makeFakeVideoStream(160, 120);
 
-            (track as any).stream = differentResStream;
+            (track as any)._rawVideo.srcObject = differentResStream;
 
             await waitUntil(() => (track as any).inputTensor !== firstTensor);
 
@@ -213,12 +214,8 @@ describe('JitsiRemoteTrack decoder', () => {
     describe('if decoder fails, back to the original track', () => {
 
         it('if decoder suddenly fails, turns it off and uses original stream', async () => {
-            const attachSpy = spyOn(RTCUtils, 'attachMediaStream').and.callThrough();
             track.increaseResolution(container);
             await waitUntil(() => track.isDecoderOn()=== true);
-            const originalStream = (track as any).stream;
-            const decodedStream = (track as any)._decodedStream;
-
             const ort = require('onnxruntime-web');
             const badTensor = new ort.Tensor('float32', new Float32Array(0), [ 0, 0, 0, 0 ]);
 
@@ -230,17 +227,10 @@ describe('JitsiRemoteTrack decoder', () => {
             expect(track.isProcessingFrame).toBe(false);
             expect(track.isDecoderOn()).toBe(false);
             expect((track as any)._animationFrameId).not.toBeNull();
-
-            const lastCall = attachSpy.calls.mostRecent();
-            expect(lastCall).toBeDefined();
-            expect(lastCall.args[0]).toBe(container);
-            expect(lastCall.args[1]).toBe(originalStream);
-            expect(lastCall.args[1]).not.toBe(decodedStream);
         });
 
         it('does not attach the decoded stream at all if decoder fails on the first frame', async () => {
 
-            const attachSpy = spyOn(RTCUtils, 'attachMediaStream').and.callThrough();
             const runSpy = spyOn(decodingSession, 'run').and.rejectWith(new Error('injected failure'));
 
             track.increaseResolution(container);
@@ -252,50 +242,37 @@ describe('JitsiRemoteTrack decoder', () => {
             expect(track.isDecoderOn()).toBe(false);
             expect((track as any)._animationFrameId).not.toBeNull();
 
-            expect(attachSpy).not.toHaveBeenCalled();
         });
 
         
         it('turns decoder off and falls back to original stream when resolution rises above 240p', async () => {
-            const attachSpy = spyOn(RTCUtils, 'attachMediaStream').and.callThrough();
-
             track.increaseResolution(container);
             await waitUntil(() => track.isDecoderOn() === true);
 
-            const originalStream = (track as any).stream;
-            const decodedStream = (track as any)._decodedStream;
-
             const { stream: highResStream, stop: stopHighRes } = makeFakeVideoStream(640, 480);
 
-            (track as any).stream = highResStream;
+            (track as any)._rawVideo.srcObject = highResStream;
 
             await waitUntil(() => track.isDecoderOn() === false);
 
             expect((track as any).shouldDecode).toBe(false);
             expect(track.isDecoderOn()).toBe(false);
 
-            const lastCall = attachSpy.calls.mostRecent();
-
-            expect(lastCall).toBeDefined();
-            expect(lastCall.args[0]).toBe(container);
-            expect(lastCall.args[1]).toBe(highResStream);
-            expect(lastCall.args[1]).not.toBe(originalStream);
-            expect(lastCall.args[1]).not.toBe(decodedStream);
-
             stopHighRes();
         });
 
         it('If processFrame fails, the loop keeps working and tries the next frame', async () => {
 
-            // simulate processFrame failure
-            const grabFrameSpy = jasmine.createSpy('grabFrame').and.rejectWith(new Error('grabFrame injected failure'));
-            spyOn(window as any, 'ImageCapture').and.returnValue({ grabFrame: grabFrameSpy });
-
             track.increaseResolution(container);
-            await waitUntil(() => grabFrameSpy.calls.count() >= 2);
+            await waitUntil(() => track.isDecoderOn() === true);
+
+            const runSpy = spyOn(decodingSession, 'run').and.rejectWith(new Error('injected failure'));
+
+            await waitUntil(() => runSpy.calls.count() >= 2, 4000);
 
             expect((track as any)._animationFrameId).not.toBeNull();
-            expect(grabFrameSpy).toHaveBeenCalled();
+            expect((track as any).shouldDecode).toBe(false);
+            expect(track.isDecoderOn()).toBe(false);
         });
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The meet was visibly blinking when the decoder was switching between on/off. It was happening because of the track switching. This PR removes track switching entirely. Instead, it either uses the original or the decoder's input (depending on conditions). 

## Related Issue

[PB-6488](https://inxt.atlassian.net/browse/PB-6488)

## How Has This Been Tested?

QA locally

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

[PB-6488]: https://inxt.atlassian.net/browse/PB-6488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ