### PR TITLE
[PB-6546] Re-size canvas independent of tensor, add logs

### DIFF
--- a/modules/RTC/JitsiRemoteTrack.ts
+++ b/modules/RTC/JitsiRemoteTrack.ts
@@ -507,15 +507,25 @@ export default class JitsiRemoteTrack extends JitsiTrack {
             if (this.shouldDecode) {
                 try {
                     // check wether the canvas must be changed
+                    if (canvasEncoded.width !== nwidth || canvasEncoded.height !== nheight) {
+                        console.log('[VIDEO BUG]: changeing encoding canvas from:', canvasEncoded.width, 'x', canvasEncoded.height, 'to', nwidth, 'x', nheight);
+                        canvasEncoded.width = nwidth;
+                        canvasEncoded.height = nheight;
+                    }
+
+                    if (canvasDecoded.width !== nwidth * 2 || canvasDecoded.height !== nheight * 2) {
+                        console.log('[VIDEO BUG]: changeing decoded canvas from:', canvasDecoded.width, 'x', canvasDecoded.height, 'to', nwidth, 'x', nheight);
+                        canvasDecoded.width = nwidth * 2;
+                        canvasDecoded.height = nheight * 2;
+                    }
+
+                    // check wether the tensor must be re-allocated
                     if (this.width != nwidth || this.height != nheight || !this.dataOutput || !this.inputBuffer) {
+                        console.log('[VIDEO BUG]: re-allocating tensor from:', this.width, 'x', this.height, 'to', nwidth, 'x', nheight);
                         if (this.inputTensor) {
                             this.inputTensor.dispose();
                             this.inputTensor = null;
                         }
-                        canvasEncoded.width = nwidth;
-                        canvasEncoded.height = nheight;
-                        canvasDecoded.width = nwidth * 2;
-                        canvasDecoded.height = nheight * 2;
                         this.inputBuffer = new Float32Array(nwidth * nheight * 4);
                         this.inputTensor = new ort.Tensor('float32', this.inputBuffer, [ 1, nheight, nwidth, 4 ]);
                         this.dataOutput = new ImageData(2 * nwidth, 2 * nheight);

--- a/modules/RTC/JitsiRemoteTrack.ts
+++ b/modules/RTC/JitsiRemoteTrack.ts
@@ -508,20 +508,20 @@ export default class JitsiRemoteTrack extends JitsiTrack {
                 try {
                     // check wether the canvas must be changed
                     if (canvasEncoded.width !== nwidth || canvasEncoded.height !== nheight) {
-                        console.log('[VIDEO BUG]: changeing encoding canvas from:', canvasEncoded.width, 'x', canvasEncoded.height, 'to', nwidth, 'x', nheight);
+                        console.log('Decoder: changeing encoding canvas from:', canvasEncoded.width, 'x', canvasEncoded.height, 'to', nwidth, 'x', nheight);
                         canvasEncoded.width = nwidth;
                         canvasEncoded.height = nheight;
                     }
 
                     if (canvasDecoded.width !== nwidth * 2 || canvasDecoded.height !== nheight * 2) {
-                        console.log('[VIDEO BUG]: changeing decoded canvas from:', canvasDecoded.width, 'x', canvasDecoded.height, 'to', nwidth, 'x', nheight);
+                        console.log('Decoder: changeing decoded canvas from:', canvasDecoded.width, 'x', canvasDecoded.height, 'to', nwidth * 2, 'x', nheight * 2);
                         canvasDecoded.width = nwidth * 2;
                         canvasDecoded.height = nheight * 2;
                     }
 
                     // check wether the tensor must be re-allocated
                     if (this.width != nwidth || this.height != nheight || !this.dataOutput || !this.inputBuffer) {
-                        console.log('[VIDEO BUG]: re-allocating tensor from:', this.width, 'x', this.height, 'to', nwidth, 'x', nheight);
+                        console.log('Decoder: re-allocating tensor from:', this.width, 'x', this.height, 'to', nwidth, 'x', nheight);
                         if (this.inputTensor) {
                             this.inputTensor.dispose();
                             this.inputTensor = null;

--- a/modules/RTC/JitsiRemoteTrack.ts
+++ b/modules/RTC/JitsiRemoteTrack.ts
@@ -508,13 +508,13 @@ export default class JitsiRemoteTrack extends JitsiTrack {
                 try {
                     // check wether the canvas must be changed
                     if (canvasEncoded.width !== nwidth || canvasEncoded.height !== nheight) {
-                        console.log('Decoder: changeing encoding canvas from:', canvasEncoded.width, 'x', canvasEncoded.height, 'to', nwidth, 'x', nheight);
+                        console.log('Decoder: changing encoding canvas from:', canvasEncoded.width, 'x', canvasEncoded.height, 'to', nwidth, 'x', nheight);
                         canvasEncoded.width = nwidth;
                         canvasEncoded.height = nheight;
                     }
 
                     if (canvasDecoded.width !== nwidth * 2 || canvasDecoded.height !== nheight * 2) {
-                        console.log('Decoder: changeing decoded canvas from:', canvasDecoded.width, 'x', canvasDecoded.height, 'to', nwidth * 2, 'x', nheight * 2);
+                        console.log('Decoder: changing decoded canvas from:', canvasDecoded.width, 'x', canvasDecoded.height, 'to', nwidth * 2, 'x', nheight * 2);
                         canvasDecoded.width = nwidth * 2;
                         canvasDecoded.height = nheight * 2;
                     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lib-meet",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lib-meet",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@hexagon/base64": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lib-meet",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "JS library for accessing Jitsi server side deployments",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

Fixes a bug where a second smaller screen appeared on top of the existing frozen one. 

The decoded canvas was changed outside of the decoder function whenever the decoder was off, yet its size was not reset properly.

## Related Issue

Fixes [PB-6546](https://inxt.atlassian.net/browse/PB-6546)

## How Has This Been Tested?

QA locally. Start a call between 2 browsers and observe that sometimes decoded canvas size changes are applied without modifying the tensor or the encoding canvas (and that bug is not happening anymore):
```

JitsiRemoteTrack.ts:511 [VIDEO BUG]: changeing encoding canvas from: 300 x 150 to 320 x 180
JitsiRemoteTrack.ts:517 [VIDEO BUG]: changeing decoded canvas from: 300 x 150 to 640 x 360
JitsiRemoteTrack.ts:524 [VIDEO BUG]: re-allocating tensor from: 0 x 0 to 320 x 180

JitsiRemoteTrack.ts:511 [VIDEO BUG]: changeing encoding canvas from: 300 x 150 to 320 x 180
JitsiRemoteTrack.ts:517 [VIDEO BUG]: changeing decoded canvas from: 300 x 150 to 640 x 360
JitsiRemoteTrack.ts:524 [VIDEO BUG]: re-allocating tensor from: 0 x 0 to 320 x 180

JitsiRemoteTrack.ts:517 [VIDEO BUG]: changeing decoded canvas from: 1280 x 720 to 640 x 360
```

## Screenshots or GIF (In case of UI changes):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

[PB-6546]: https://inxt.atlassian.net/browse/PB-6546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ